### PR TITLE
upgraded Contentful

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -7,10 +7,6 @@ export default defineNuxtConfig({
     '@nuxt/eslint',
   ],
 
-  build: {
-    transpile: ['contentful'],
-  },
-
   css: [
     '~/assets/css/main.scss',
     '~/assets/css/variables.scss',

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@contentful/rich-text-html-renderer": "^16.6.9",
     "@pinia/nuxt": "^0.5.5",
     "aws-amplify": "^6.6.7",
-    "contentful": "^10.15.1",
+    "contentful": "^10.15.2",
     "nuxt": "^3.14.0",
     "pinia": "^2.2.6",
     "vue": "^3.5.13",

--- a/plugins/contentful.ts
+++ b/plugins/contentful.ts
@@ -4,9 +4,7 @@
  * Provides access to Contentful client for fetching CMS content
  * like hero sections, team bios, service descriptions, etc.
  */
-import contentful, { type ContentfulClientApi, type EntrySkeletonType } from 'contentful'
-
-const { createClient } = contentful
+import { createClient, type ContentfulClientApi, type EntrySkeletonType } from 'contentful'
 
 export default defineNuxtPlugin(() => {
   const runtimeConfig = useRuntimeConfig()


### PR DESCRIPTION
Contentful v10.15.1 only shipped UMD bundles with no proper ESM exports, which Vite's dev server couldn't handle regardless of configuration. Upgraded to contentful v10.15.2, which added a proper ESM build (dist/esm/index.js) with a correct exports field. Vite and Node.js now both natively pick the right build for their context.