### PR TITLE
Added admin page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,15 @@ SITE_URL=http://localhost:3000
 ORCID_CLIENT_ID=APP-XXXXXXXXX
 ORCID_API_HOST=https://sandbox.orcid.org
 
+# Signing secret for agreement email links (generate with: openssl rand -hex 32)
+SIGNING_SECRET=your-random-64-char-hex-secret
+
+# Supabase Configuration
+# Get these from Supabase dashboard → Project Settings → API Keys
+NUXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NUXT_PUBLIC_SUPABASE_KEY=your-publishable-key
+NUXT_SUPABASE_SECRET_KEY=your-secret-key
+
 # MailerSend Email Configuration
 MAILERSEND_API_TOKEN=your_mailersend_api_token
 MAILERSEND_FROM_EMAIL=noreply@test-q3enl6k3n8042vwr.mlsender.net

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ logs
 
 # TypeScript
 *.tsbuildinfo
+
+# Claude
+.claude

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -1,0 +1,2182 @@
+/*
+ * Admin Console Styles
+ * Shared styles for the IH3 Admin Console.
+ * Uses the same design tokens as the public site (variables.scss).
+ */
+
+@import url('https://fonts.googleapis.com/css2?family=Dancing+Script:wght@600;700&display=swap');
+
+/* =========================================================
+   Admin badge system (extends base .badge from main.scss)
+   ========================================================= */
+.adm-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.66rem;
+  font-weight: 600;
+  padding: 0.18rem 0.55rem;
+  border-radius: var(--radius);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+
+  .dot {
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: currentColor;
+    flex-shrink: 0;
+  }
+}
+
+.b-review     { background: rgba(183,149,11,0.12);  color: var(--gold); }
+.b-agreement  { background: rgba(13,115,119,0.10);  color: var(--teal); }
+.b-processing { background: rgba(183,149,11,0.12);  color: var(--gold); }
+.b-complete   { background: rgba(26,122,76,0.10);   color: var(--green); }
+.b-warn       { background: rgba(192,57,43,0.10);   color: var(--warm); }
+.b-muted      { background: rgba(127,140,141,0.12); color: var(--muted); }
+.b-industry   { background: rgba(108,52,131,0.10);  color: #6c3483; }
+.b-external   { background: rgba(41,128,185,0.10);  color: #1f6391; }
+.b-internal   { background: rgba(1,31,91,0.08);     color: var(--accent); }
+
+/* =========================================================
+   Admin button overrides
+   ========================================================= */
+.admin-shell {
+  .btn-secondary {
+    background: transparent;
+    color: var(--penn-blue);
+    border: 1.5px solid var(--penn-light-blue);
+
+    &:hover:not(:disabled) {
+      background: var(--penn-blue);
+      color: #fff;
+    }
+  }
+
+  .btn-ghost {
+    background: transparent;
+    color: #2b3a4a;
+    border: 1px solid transparent;
+
+    &:hover:not(:disabled) {
+      background: rgba(1,31,91,0.05);
+      color: var(--ink);
+    }
+  }
+
+  .btn-sm {
+    padding: 0.35rem 0.85rem;
+    font-size: 0.78rem;
+  }
+
+  .link-btn {
+    font-size: 0.8rem;
+    color: var(--penn-blue);
+    font-weight: 600;
+    cursor: pointer;
+    border: none;
+    background: none;
+    font-family: inherit;
+    padding: 0;
+
+    &:hover { text-decoration: underline; }
+  }
+}
+
+/* =========================================================
+   Admin page shell (topbar + sidebar + main)
+   ========================================================= */
+.admin-shell {
+  --sidebar-w: 232px;
+  --topbar-h: 56px;
+  --ink-soft: #2b3a4a;
+
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.admin-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  height: var(--topbar-h);
+  background: rgba(244,241,235,0.92);
+  backdrop-filter: blur(16px);
+  border-bottom: 1px solid rgba(0,0,0,0.06);
+  display: flex;
+  align-items: center;
+  padding: 0 1.4rem;
+  gap: 1.2rem;
+
+  .brand {
+    font-family: 'DM Serif Display', serif;
+    font-size: 1.05rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-right: 0.4rem;
+    text-decoration: none;
+    color: var(--ink);
+  }
+
+  .brand .mark {
+    width: 26px;
+    height: 26px;
+    background: var(--penn-blue);
+    border-radius: var(--radius);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-weight: 700;
+    font-size: 0.62rem;
+    font-family: 'JetBrains Mono', monospace;
+  }
+
+  .scope-pill {
+    font-size: 0.65rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    padding: 0.2rem 0.6rem;
+    border-radius: 100px;
+    background: rgba(1,31,91,0.08);
+    color: var(--penn-blue);
+    border: 1px solid rgba(1,31,91,0.14);
+  }
+
+  .topbar-spacer { flex: 1; }
+
+  .topbar-search {
+    width: 320px;
+    position: relative;
+
+    input {
+      padding-left: 2.1rem;
+      background: rgba(255,255,255,0.6);
+    }
+
+    &::before {
+      content: '⌕';
+      position: absolute;
+      left: 0.7rem;
+      top: 50%;
+      transform: translateY(-50%);
+      color: var(--muted);
+      font-size: 0.95rem;
+      pointer-events: none;
+    }
+  }
+
+  .user-pill {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.25rem 0.7rem 0.25rem 0.3rem;
+    border-radius: 100px;
+    border: 1px solid rgba(0,0,0,0.08);
+    background: #fff;
+    font-size: 0.82rem;
+    cursor: pointer;
+    position: relative;
+    user-select: none;
+
+    &:hover { background: rgba(255,255,255,0.95); }
+
+    .av {
+      width: 26px;
+      height: 26px;
+      border-radius: 50%;
+      background: var(--teal);
+      color: #fff;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.62rem;
+      font-weight: 600;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .pill-name { font-weight: 600; line-height: 1.1; }
+    .pill-role {
+      font-size: 0.6rem;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .caret { color: var(--muted); font-size: 0.7rem; margin-left: 0.4rem; }
+  }
+}
+
+/* =========================================================
+   Sidebar
+   ========================================================= */
+.admin-sidebar {
+  border-right: 1px solid rgba(0,0,0,0.06);
+  background: rgba(255,255,255,0.4);
+  padding: 1.4rem 0.8rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  width: var(--sidebar-w);
+  flex-shrink: 0;
+  min-height: calc(100vh - var(--topbar-h));
+
+  .sb-section {
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--muted);
+    font-weight: 600;
+    padding: 0.7rem 0.75rem 0.4rem;
+  }
+
+  .sb-link {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.55rem 0.75rem;
+    border-radius: var(--radius);
+    font-size: 0.86rem;
+    font-weight: 500;
+    color: var(--ink-soft, #2b3a4a);
+    border: 1px solid transparent;
+    cursor: pointer;
+    background: transparent;
+    text-align: left;
+    width: 100%;
+    font-family: inherit;
+    text-decoration: none;
+
+    &:hover { background: rgba(1,31,91,0.05); color: var(--ink); }
+
+    &.active, &.router-link-active {
+      background: var(--penn-blue);
+      color: #fff;
+
+      .sb-count {
+        background: rgba(255,255,255,0.18);
+        color: #fff;
+      }
+    }
+
+    .sb-ico {
+      width: 18px;
+      height: 18px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.95rem;
+      opacity: 0.9;
+    }
+
+    .sb-count {
+      margin-left: auto;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.65rem;
+      font-weight: 600;
+      padding: 0.1rem 0.45rem;
+      border-radius: 100px;
+      background: rgba(1,31,91,0.08);
+      color: var(--accent);
+    }
+  }
+
+  .sb-footer {
+    margin-top: auto;
+    padding: 1rem 0.75rem;
+    font-size: 0.72rem;
+    color: var(--muted);
+    line-height: 1.5;
+    border-top: 1px solid rgba(0,0,0,0.05);
+  }
+}
+
+/* =========================================================
+   Main body (sidebar + content)
+   ========================================================= */
+.admin-body {
+  display: flex;
+  flex: 1;
+}
+
+.admin-main {
+  padding: 2rem 2.4rem 4rem;
+  max-width: 1240px;
+  width: 100%;
+  flex: 1;
+}
+
+/* =========================================================
+   User menu dropdown
+   ========================================================= */
+.user-menu {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  background: #fff;
+  border: 1px solid rgba(0,0,0,0.08);
+  border-radius: var(--radius);
+  box-shadow: 0 8px 30px rgba(0,0,0,0.12);
+  min-width: 230px;
+  z-index: 100;
+  overflow: hidden;
+
+  .who {
+    padding: 0.85rem 1rem 0.7rem;
+    border-bottom: 1px solid rgba(0,0,0,0.05);
+
+    .um-name { font-weight: 600; font-size: 0.88rem; }
+    .um-email {
+      font-size: 0.74rem;
+      color: var(--muted);
+      font-family: 'JetBrains Mono', monospace;
+    }
+    .um-session {
+      display: flex;
+      align-items: center;
+      gap: 0.35rem;
+      font-size: 0.7rem;
+      color: var(--green);
+      margin-top: 0.4rem;
+      font-weight: 500;
+
+      .dot {
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: var(--green);
+      }
+    }
+  }
+
+  .um-item {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.55rem 1rem;
+    font-size: 0.85rem;
+    color: #2b3a4a;
+    background: transparent;
+    border: none;
+    width: 100%;
+    text-align: left;
+    cursor: pointer;
+    font-family: inherit;
+
+    &:hover { background: rgba(1,31,91,0.04); color: var(--ink); }
+    .ico { width: 16px; opacity: 0.7; }
+
+    &.danger {
+      color: var(--warm);
+      border-top: 1px solid rgba(0,0,0,0.05);
+      &:hover { background: rgba(192,57,43,0.06); }
+    }
+  }
+}
+
+/* =========================================================
+   Page header
+   ========================================================= */
+.page-hd {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.6rem;
+  flex-wrap: wrap;
+
+  h1 {
+    font-family: 'DM Serif Display', serif;
+    font-weight: 400;
+    font-size: 1.9rem;
+    line-height: 1.1;
+  }
+
+  .sub {
+    font-size: 0.88rem;
+    color: var(--muted);
+    font-weight: 300;
+    margin-top: 0.25rem;
+  }
+
+  .hd-actions {
+    display: flex;
+    gap: 0.6rem;
+    align-items: center;
+    flex-shrink: 0;
+  }
+}
+
+/* =========================================================
+   KPI tiles
+   ========================================================= */
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+  margin-bottom: 1.6rem;
+
+  @media (max-width: 1000px) { grid-template-columns: repeat(2, 1fr); }
+}
+
+.kpi-card {
+  background: var(--card);
+  border-radius: var(--radius);
+  padding: 1.2rem 1.3rem;
+  box-shadow: var(--card-shadow);
+  border: 1px solid rgba(0,0,0,0.03);
+  position: relative;
+  overflow: hidden;
+
+  &.warn { border-left: 3px solid var(--gold); }
+  &.warn .kpi-val { color: var(--gold); }
+
+  .kpi-lbl {
+    font-size: 0.66rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--muted);
+    font-weight: 600;
+    margin-bottom: 0.55rem;
+  }
+
+  .kpi-val {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 2.05rem;
+    font-weight: 500;
+    line-height: 1;
+    color: var(--ink);
+    letter-spacing: -0.02em;
+  }
+
+  .kpi-ctx {
+    font-size: 0.74rem;
+    color: var(--muted);
+    margin-top: 0.45rem;
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+
+  .delta-up { color: var(--green); font-weight: 600; }
+  .delta-down { color: var(--warm); font-weight: 600; }
+}
+
+/* =========================================================
+   Alerts strip
+   ========================================================= */
+.alerts-strip {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  margin-bottom: 1.6rem;
+}
+
+.alert-row {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  padding: 0.7rem 1rem;
+  border-radius: var(--radius);
+  background: #fff;
+  border: 1px solid rgba(0,0,0,0.05);
+  border-left: 3px solid var(--gold);
+  font-size: 0.85rem;
+
+  &.error { border-left-color: var(--warm); }
+  &.info  { border-left-color: var(--accent); }
+
+  .alert-meta {
+    margin-left: auto;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.72rem;
+    color: var(--muted);
+    flex-shrink: 0;
+  }
+
+  .alert-act {
+    font-size: 0.78rem;
+    color: var(--penn-blue);
+    font-weight: 600;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    white-space: nowrap;
+    font-family: inherit;
+
+    &:hover { text-decoration: underline; }
+  }
+}
+
+/* =========================================================
+   Panel card
+   ========================================================= */
+.panel {
+  background: var(--card);
+  border-radius: var(--radius);
+  box-shadow: var(--card-shadow);
+  border: 1px solid rgba(0,0,0,0.03);
+  overflow: hidden;
+
+  .panel-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.1rem 1.4rem 0.5rem;
+
+    h3 { font-size: 0.95rem; font-weight: 600; }
+    .ctx { font-size: 0.74rem; color: var(--muted); font-weight: 400; }
+  }
+
+  .panel-body { padding: 0.6rem 0 0.4rem; }
+
+  .panel-foot {
+    padding: 0.6rem 1.4rem 1rem;
+    border-top: 1px solid rgba(0,0,0,0.04);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.6rem;
+  }
+}
+
+/* List rows inside panels */
+.panel-row {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  padding: 0.7rem 1.4rem;
+  border-bottom: 1px solid rgba(0,0,0,0.04);
+
+  &:last-child { border-bottom: none; }
+  &:hover { background: rgba(1,31,91,0.02); }
+
+  .row-pri { font-weight: 600; font-size: 0.86rem; }
+  .row-sec { font-size: 0.74rem; color: var(--muted); margin-top: 0.1rem; }
+  .row-right { margin-left: auto; display: flex; align-items: center; gap: 0.7rem; }
+  .row-when {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.72rem;
+    color: var(--muted);
+  }
+}
+
+/* =========================================================
+   Table
+   ========================================================= */
+.table-wrap {
+  background: var(--card);
+  border-radius: var(--radius);
+  box-shadow: var(--card-shadow);
+  border: 1px solid rgba(0,0,0,0.03);
+  overflow: hidden;
+}
+
+table.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.86rem;
+
+  thead th {
+    text-align: left;
+    padding: 0.85rem 1.1rem;
+    font-size: 0.66rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-weight: 600;
+    color: var(--muted);
+    border-bottom: 1px solid var(--line);
+    background: var(--cream);
+    white-space: nowrap;
+  }
+
+  tbody td {
+    padding: 0.85rem 1.1rem;
+    border-bottom: 1px solid rgba(0,0,0,0.04);
+    vertical-align: middle;
+  }
+
+  tbody tr {
+    cursor: pointer;
+    transition: background 0.15s;
+
+    &:hover td { background: rgba(1,31,91,0.025); }
+    &:last-child td { border-bottom: none; }
+  }
+}
+
+.study-name { font-weight: 600; color: var(--ink); }
+.study-pi { font-size: 0.76rem; color: var(--muted); margin-top: 0.1rem; }
+
+.cell-progress {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  min-width: 130px;
+}
+
+.prog-bar {
+  flex: 1;
+  height: 5px;
+  background: rgba(0,0,0,0.06);
+  border-radius: 3px;
+  overflow: hidden;
+
+  div {
+    height: 100%;
+    background: var(--green);
+    border-radius: 3px;
+  }
+
+  &.gold div   { background: var(--gold); }
+  &.warm div   { background: var(--warm); }
+  &.accent div { background: var(--accent); }
+}
+
+.prog-frac {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.74rem;
+  color: var(--muted);
+  min-width: 48px;
+  text-align: right;
+}
+
+/* =========================================================
+   Toolbar (chips + search)
+   ========================================================= */
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.chip-group {
+  display: flex;
+  background: #fff;
+  border: 1px solid rgba(0,0,0,0.07);
+  border-radius: var(--radius);
+  padding: 3px;
+  gap: 2px;
+}
+
+.chip {
+  border: none;
+  background: transparent;
+  padding: 0.38rem 0.85rem;
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--muted);
+  border-radius: 3px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  cursor: pointer;
+  font-family: inherit;
+
+  &:hover { color: var(--ink); }
+
+  &.active {
+    background: var(--penn-blue);
+    color: #fff;
+  }
+
+  .chip-count {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.66rem;
+    opacity: 0.7;
+  }
+  &.active .chip-count { opacity: 0.9; }
+}
+
+.toolbar-search {
+  position: relative;
+  width: 280px;
+
+  input { padding-left: 2.1rem; background: #fff; }
+
+  &::before {
+    content: '⌕';
+    position: absolute;
+    left: 0.7rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--muted);
+    pointer-events: none;
+  }
+}
+
+.toolbar-spacer { flex: 1; }
+
+/* =========================================================
+   Pagination
+   ========================================================= */
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.8rem 1.2rem;
+  border-top: 1px solid rgba(0,0,0,0.04);
+  font-size: 0.78rem;
+  color: var(--muted);
+}
+
+.pag-controls {
+  display: flex;
+  gap: 0.3rem;
+
+  button {
+    width: 28px;
+    height: 28px;
+    border: 1px solid var(--line);
+    background: #fff;
+    border-radius: var(--radius);
+    font-size: 0.78rem;
+    color: var(--muted);
+    cursor: pointer;
+    font-family: inherit;
+
+    &.active { background: var(--penn-blue); border-color: var(--penn-blue); color: #fff; }
+    &:hover:not(.active) { border-color: var(--penn-blue); color: var(--penn-blue); }
+  }
+}
+
+/* =========================================================
+   Breadcrumb
+   ========================================================= */
+.crumbs {
+  font-size: 0.78rem;
+  color: var(--muted);
+  margin-bottom: 0.8rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  button, .crumb-link {
+    background: none;
+    border: none;
+    color: var(--muted);
+    font-size: inherit;
+    cursor: pointer;
+    padding: 0;
+    font-family: inherit;
+
+    &:hover { color: var(--penn-blue); text-decoration: underline; }
+  }
+
+  .sep { opacity: 0.5; }
+}
+
+/* =========================================================
+   Detail hero card
+   ========================================================= */
+.detail-hero {
+  background: var(--card);
+  border-radius: var(--radius);
+  padding: 1.6rem 1.8rem;
+  box-shadow: var(--card-shadow);
+  border: 1px solid rgba(0,0,0,0.03);
+  margin-bottom: 1.4rem;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 1.4rem;
+  align-items: center;
+
+  @media (max-width: 900px) { grid-template-columns: 1fr; }
+
+  h2 {
+    font-family: 'DM Serif Display', serif;
+    font-weight: 400;
+    font-size: 1.55rem;
+    margin-bottom: 0.4rem;
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    flex-wrap: wrap;
+  }
+
+  .acronym {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.78rem;
+    font-weight: 500;
+    letter-spacing: 0.05em;
+    padding: 0.2rem 0.55rem;
+    background: rgba(1,31,91,0.08);
+    border-radius: var(--radius);
+    color: var(--accent);
+    text-transform: uppercase;
+  }
+
+  .pi-line {
+    font-size: 0.92rem;
+    color: var(--muted);
+    font-weight: 300;
+
+    strong { color: var(--ink); font-weight: 500; }
+  }
+
+  .meta-strip {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.2rem;
+    margin-top: 0.9rem;
+    font-size: 0.78rem;
+
+    .meta-item {
+      .meta-label {
+        display: block;
+        font-size: 0.62rem;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--muted);
+        font-weight: 600;
+        margin-bottom: 0.15rem;
+      }
+      .meta-val {
+        font-family: 'JetBrains Mono', monospace;
+        color: var(--ink);
+        font-size: 0.84rem;
+      }
+    }
+  }
+
+  .hero-actions {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.55rem;
+  }
+}
+
+.status-strip {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.9rem;
+  border-radius: var(--radius);
+  background: rgba(183,149,11,0.08);
+  border: 1px solid rgba(183,149,11,0.2);
+
+  .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--gold);
+    box-shadow: 0 0 0 4px rgba(183,149,11,0.15);
+  }
+
+  .txt { font-size: 0.78rem; font-weight: 600; color: var(--gold); }
+}
+
+/* =========================================================
+   Lifecycle timeline
+   ========================================================= */
+.lifecycle-section {
+  background: var(--card);
+  border-radius: var(--radius);
+  box-shadow: var(--card-shadow);
+  border: 1px solid rgba(0,0,0,0.03);
+  padding: 1.4rem 1.8rem 1.6rem;
+  margin-bottom: 1.4rem;
+
+  h3 { font-size: 0.95rem; font-weight: 600; margin-bottom: 0.2rem; }
+  .sub { font-size: 0.78rem; color: var(--muted); margin-bottom: 1.2rem; }
+}
+
+.life-timeline {
+  display: flex;
+  align-items: stretch;
+  flex-wrap: wrap;
+}
+
+.life-step {
+  flex: 1;
+  text-align: center;
+  position: relative;
+  padding-top: 2.6rem;
+  min-width: 90px;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 11px;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: var(--line);
+  }
+
+  &:first-child::before { left: 50%; }
+  &:last-child::before  { right: 50%; }
+
+  &.done::before   { background: var(--penn-blue); }
+  &.active::before { background: linear-gradient(90deg, var(--penn-blue) 50%, var(--line) 50%); }
+
+  .life-dot {
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    border: 2.5px solid var(--line);
+    background: var(--card);
+    position: absolute;
+    top: 1px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 2;
+    transition: all 0.3s;
+  }
+
+  &.done .life-dot {
+    background: var(--penn-blue);
+    border-color: var(--penn-blue);
+  }
+
+  &.active .life-dot {
+    background: var(--penn-blue);
+    border-color: var(--penn-blue);
+    box-shadow: 0 0 0 4px rgba(1,31,91,0.18);
+  }
+
+  .life-label {
+    font-size: 0.7rem;
+    font-weight: 500;
+    color: var(--muted);
+  }
+
+  .life-when {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.62rem;
+    color: var(--muted);
+    margin-top: 0.2rem;
+    opacity: 0.8;
+  }
+
+  &.done .life-label  { color: var(--penn-blue); }
+  &.active .life-label { color: var(--penn-blue); font-weight: 600; }
+}
+
+/* =========================================================
+   Tabs
+   ========================================================= */
+.tabs {
+  display: flex;
+  margin-bottom: 1.4rem;
+  border-bottom: 1px solid rgba(0,0,0,0.06);
+}
+
+.tab-btn {
+  border: none;
+  background: transparent;
+  padding: 0.7rem 1.1rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--muted);
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: all 0.15s;
+  cursor: pointer;
+  font-family: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+
+  &:hover { color: var(--ink); }
+
+  &.active {
+    color: var(--penn-blue);
+    border-bottom-color: var(--penn-blue);
+    font-weight: 600;
+  }
+
+  .tab-count {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.66rem;
+    padding: 0.08rem 0.4rem;
+    border-radius: 100px;
+    background: rgba(1,31,91,0.08);
+    color: var(--accent);
+  }
+
+  &.active .tab-count { background: var(--penn-blue); color: #fff; }
+}
+
+/* =========================================================
+   Two-column detail grid
+   ========================================================= */
+.dt-grid {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 1.2rem;
+
+  @media (max-width: 1000px) { grid-template-columns: 1fr; }
+}
+
+.dash-cols {
+  display: grid;
+  grid-template-columns: 1.55fr 1fr;
+  gap: 1.2rem;
+
+  @media (max-width: 1000px) { grid-template-columns: 1fr; }
+}
+
+/* =========================================================
+   Activity timeline (notes)
+   ========================================================= */
+.activity-timeline {
+  padding: 0 1.4rem 1.2rem;
+}
+
+.t-item {
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  gap: 0.8rem;
+  position: relative;
+  padding: 0.55rem 0;
+
+  &::before {
+    content: '';
+    position: absolute;
+    left: 13.5px;
+    top: 1.5rem;
+    bottom: -0.55rem;
+    width: 1px;
+    background: rgba(0,0,0,0.08);
+  }
+
+  &:last-child::before { display: none; }
+}
+
+.t-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin: 0.5rem 0 0 9px;
+  background: var(--penn-blue);
+  box-shadow: 0 0 0 3px var(--card);
+  position: relative;
+  z-index: 2;
+  flex-shrink: 0;
+
+  &.g { background: var(--green); }
+  &.w { background: var(--gold); }
+  &.r { background: var(--warm); }
+  &.m { background: var(--muted); }
+}
+
+.t-body {
+  .t-title { font-size: 0.86rem; font-weight: 500; }
+  .t-meta {
+    font-size: 0.74rem;
+    color: var(--muted);
+    margin-top: 0.15rem;
+    font-family: 'JetBrains Mono', monospace;
+  }
+  .t-note {
+    font-size: 0.84rem;
+    color: #444;
+    font-weight: 300;
+    margin-top: 0.3rem;
+    background: var(--cream);
+    padding: 0.55rem 0.8rem;
+    border-radius: var(--radius);
+    border-left: 2px solid rgba(0,0,0,0.06);
+  }
+}
+
+/* =========================================================
+   Note composer
+   ========================================================= */
+.note-composer {
+  padding: 1rem 1.4rem 1.2rem;
+  border-top: 1px solid rgba(0,0,0,0.05);
+
+  textarea { min-height: 70px; resize: vertical; }
+
+  .composer-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    margin-top: 0.55rem;
+  }
+}
+
+/* =========================================================
+   Agreements tab
+   ========================================================= */
+.agree-item {
+  display: grid;
+  grid-template-columns: 36px minmax(180px, 1.2fr) auto auto;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.4rem;
+  border-bottom: 1px solid rgba(0,0,0,0.04);
+
+  &:last-child { border-bottom: none; }
+  &.pending-bg { background: rgba(183,149,11,0.03); }
+}
+
+.agree-check {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 2px solid var(--line);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: transparent;
+  flex-shrink: 0;
+
+  &.signed { background: var(--green); border-color: var(--green); color: #fff; }
+  &.pending { border-color: var(--gold); background: rgba(183,149,11,0.08); color: var(--gold); }
+}
+
+.agree-name { font-weight: 600; font-size: 0.88rem; }
+.agree-desc { font-size: 0.74rem; color: var(--muted); margin-top: 0.15rem; }
+
+/* Clerk-style signature stamp */
+.sig-stamp {
+  background: var(--cream);
+  border: 1px solid rgba(0,0,0,0.06);
+  border-radius: var(--radius);
+  padding: 0.6rem 0.85rem;
+  display: inline-block;
+  min-width: 200px;
+
+  .sig-name {
+    font-family: 'Dancing Script', cursive;
+    font-size: 1.3rem;
+    font-weight: 600;
+    color: var(--accent);
+    line-height: 1.1;
+  }
+
+  .sig-meta { font-size: 0.74rem; color: var(--muted); margin-top: 0.45rem; }
+
+  .sig-verified {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.74rem;
+    color: var(--accent);
+    font-weight: 500;
+    margin-top: 0.2rem;
+
+    svg { width: 14px; height: 14px; flex-shrink: 0; }
+  }
+}
+
+.sig-pending {
+  background: rgba(183,149,11,0.06);
+  border: 1px dashed rgba(183,149,11,0.4);
+  border-radius: var(--radius);
+  padding: 0.85rem 1.1rem;
+  display: inline-block;
+  min-width: 220px;
+  text-align: center;
+  font-size: 0.78rem;
+  color: var(--gold);
+  font-weight: 500;
+
+  .sig-pend-ttl { display: block; font-weight: 600; margin-bottom: 0.2rem; }
+  .sig-pend-sub { font-size: 0.72rem; color: var(--muted); font-weight: 400; }
+}
+
+/* =========================================================
+   Locked banner
+   ========================================================= */
+.locked-banner {
+  background: linear-gradient(135deg, rgba(183,149,11,0.08), rgba(192,57,43,0.05));
+  border: 1px solid rgba(183,149,11,0.22);
+  border-left: 3px solid var(--gold);
+  border-radius: var(--radius);
+  padding: 1rem 1.3rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.4rem;
+  flex-wrap: wrap;
+
+  .lock-icon {
+    width: 36px;
+    height: 36px;
+    flex-shrink: 0;
+    border-radius: 50%;
+    background: rgba(183,149,11,0.15);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--gold);
+  }
+
+  .lock-body {
+    flex: 1;
+
+    h4 { font-size: 0.92rem; font-weight: 600; margin-bottom: 0.15rem; }
+    p  { font-size: 0.82rem; color: #2b3a4a; font-weight: 300; line-height: 1.5; }
+
+    .frac { font-family: 'JetBrains Mono', monospace; font-weight: 600; color: var(--gold); }
+  }
+
+  .lock-actions { display: flex; gap: 0.5rem; flex-shrink: 0; }
+}
+
+.locked-empty {
+  background: var(--card);
+  border-radius: var(--radius);
+  box-shadow: var(--card-shadow);
+  border: 1px solid rgba(0,0,0,0.03);
+  padding: 4rem 2rem;
+  text-align: center;
+
+  .ico-big {
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    background: rgba(183,149,11,0.1);
+    color: var(--gold);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto 1.2rem;
+  }
+
+  h3 {
+    font-family: 'DM Serif Display', serif;
+    font-weight: 400;
+    font-size: 1.35rem;
+    margin-bottom: 0.4rem;
+  }
+
+  p {
+    color: var(--muted);
+    font-weight: 300;
+    font-size: 0.92rem;
+    max-width: 460px;
+    margin: 0 auto 1.4rem;
+    line-height: 1.6;
+  }
+}
+
+/* =========================================================
+   Budget tab
+   ========================================================= */
+.budget-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.8rem;
+  padding: 0.4rem 1.4rem 1rem;
+}
+
+.budget-card {
+  background: var(--cream);
+  border-radius: var(--radius);
+  border: 1px solid rgba(0,0,0,0.04);
+  padding: 0.9rem 1rem;
+
+  .lbl {
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--muted);
+    font-weight: 600;
+    margin-bottom: 0.3rem;
+  }
+
+  .val {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1.15rem;
+    font-weight: 500;
+  }
+}
+
+.budget-prog {
+  margin: 0 1.4rem;
+  height: 8px;
+  border-radius: 4px;
+  background: rgba(0,0,0,0.06);
+  overflow: hidden;
+
+  div {
+    height: 100%;
+    background: linear-gradient(90deg, var(--warm), var(--warm-light));
+  }
+}
+
+table.budget-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.82rem;
+  margin-top: 1rem;
+
+  th {
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-weight: 600;
+    color: var(--muted);
+    text-align: left;
+    padding: 0.55rem 1.4rem;
+    border-bottom: 1px solid var(--line);
+  }
+
+  td {
+    padding: 0.5rem 1.4rem;
+    border-bottom: 1px solid rgba(0,0,0,0.04);
+  }
+
+  tr:last-child td { border-bottom: none; }
+}
+
+/* =========================================================
+   Integration cards
+   ========================================================= */
+.integ-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 0.6rem;
+  padding: 0.8rem 1.4rem 1.4rem;
+}
+
+.integ-card {
+  border: 1px solid rgba(0,0,0,0.05);
+  border-radius: var(--radius);
+  padding: 0.8rem 0.9rem;
+  background: var(--cream);
+
+  &.linked { border-left: 3px solid var(--green); }
+  &.pending { border-left: 3px solid var(--gold); }
+
+  .integ-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--muted);
+    margin-bottom: 0.4rem;
+  }
+
+  .integ-val {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.82rem;
+    color: var(--ink);
+    word-break: break-all;
+  }
+
+  .integ-act {
+    margin-top: 0.55rem;
+    font-size: 0.74rem;
+    color: var(--penn-blue);
+    font-weight: 600;
+    border: none;
+    background: none;
+    cursor: pointer;
+    padding: 0;
+    font-family: inherit;
+
+    &:hover { text-decoration: underline; }
+  }
+}
+
+/* =========================================================
+   Assume banner
+   ========================================================= */
+.assume-banner {
+  background: linear-gradient(135deg, rgba(1,31,91,0.05), rgba(13,115,119,0.06));
+  border-left: 3px solid var(--teal);
+  padding: 0.85rem 1.2rem;
+  border-radius: var(--radius);
+  margin-bottom: 1.6rem;
+  font-size: 0.84rem;
+  color: #2b3a4a;
+  line-height: 1.6;
+
+  strong {
+    display: block;
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    margin-bottom: 0.25rem;
+    color: var(--teal);
+    font-weight: 700;
+  }
+}
+
+/* =========================================================
+   Email preview (Communications page)
+   ========================================================= */
+.email-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.4rem;
+
+  @media (max-width: 1000px) { grid-template-columns: 1fr; }
+}
+
+.email-card {
+  background: var(--card);
+  border-radius: var(--radius);
+  box-shadow: var(--card-shadow);
+  border: 1px solid rgba(0,0,0,0.03);
+  overflow: hidden;
+
+  .email-head {
+    padding: 0.9rem 1.2rem;
+    border-bottom: 1px solid rgba(0,0,0,0.06);
+    background: var(--cream);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    h4 { font-size: 0.95rem; font-weight: 600; }
+
+    .etag {
+      font-size: 0.62rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      font-weight: 600;
+      color: var(--muted);
+    }
+  }
+
+  .email-meta {
+    font-size: 0.78rem;
+    color: var(--muted);
+    padding: 0.75rem 1.2rem;
+    border-bottom: 1px solid rgba(0,0,0,0.04);
+    font-family: 'JetBrains Mono', monospace;
+    background: rgba(244,241,235,0.4);
+
+    .l { color: var(--muted); }
+    .v { color: var(--ink); }
+
+    div { margin-bottom: 0.2rem; &:last-child { margin-bottom: 0; } }
+  }
+
+  .email-body {
+    padding: 1.6rem 1.6rem 2rem;
+    font-family: 'Source Sans 3', sans-serif;
+    font-size: 0.92rem;
+    color: #2d3640;
+    line-height: 1.75;
+    font-weight: 300;
+
+    .em-brand-row {
+      display: flex;
+      align-items: center;
+      gap: 0.55rem;
+      padding-bottom: 1.2rem;
+      border-bottom: 1px solid rgba(0,0,0,0.05);
+      margin-bottom: 1.4rem;
+
+      .mark {
+        width: 24px;
+        height: 24px;
+        background: var(--penn-blue);
+        border-radius: var(--radius);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: #fff;
+        font-family: 'JetBrains Mono', monospace;
+        font-size: 0.58rem;
+        font-weight: 700;
+      }
+
+      .name {
+        font-family: 'DM Serif Display', serif;
+        font-size: 1.05rem;
+      }
+    }
+
+    strong { color: var(--ink); font-weight: 600; }
+
+    h3 {
+      font-family: 'DM Serif Display', serif;
+      font-weight: 400;
+      font-size: 1.35rem;
+      margin-bottom: 0.6rem;
+      color: var(--ink);
+    }
+
+    .em-summary {
+      background: var(--cream);
+      border-radius: var(--radius);
+      padding: 0.9rem 1.1rem;
+      margin: 1rem 0;
+      border-left: 3px solid var(--accent);
+      font-size: 0.86rem;
+
+      .r {
+        display: flex;
+        justify-content: space-between;
+        padding: 0.18rem 0;
+        .l { color: var(--muted); }
+        .v { color: var(--ink); font-weight: 500; }
+      }
+    }
+
+    .em-cta {
+      display: inline-block;
+      background: var(--penn-blue);
+      color: #fff;
+      padding: 0.7rem 1.3rem;
+      border-radius: var(--radius);
+      font-weight: 600;
+      font-size: 0.85rem;
+      margin: 0.6rem 0;
+      cursor: pointer;
+    }
+
+    .em-signoff {
+      font-size: 0.85rem;
+      color: var(--muted);
+      margin-top: 1.4rem;
+      font-weight: 300;
+
+      strong { color: var(--ink); }
+    }
+
+    .em-legal {
+      font-size: 0.7rem;
+      color: var(--muted);
+      margin-top: 1.6rem;
+      padding-top: 1rem;
+      border-top: 1px solid rgba(0,0,0,0.05);
+      line-height: 1.6;
+    }
+  }
+}
+
+/* =========================================================
+   Quick stats grid (overview tab)
+   ========================================================= */
+.quick-stats {
+  padding: 0.6rem 1.4rem 1.4rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.6rem;
+}
+
+.qs-card {
+  padding: 0.7rem 0.9rem;
+  background: var(--cream);
+  border-radius: var(--radius);
+
+  .qs-lbl {
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--muted);
+    font-weight: 600;
+    margin-bottom: 0.2rem;
+  }
+
+  .qs-val {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1.15rem;
+    font-weight: 500;
+  }
+}
+
+/* =========================================================
+   Login page
+   ========================================================= */
+.login-shell {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+
+  @media (max-width: 900px) {
+    grid-template-columns: 1fr;
+    .login-aside { display: none; }
+  }
+}
+
+.login-aside {
+  background: linear-gradient(175deg, #0a0f1a 0%, #011F5B 45%, #1a5276 100%);
+  color: #fff;
+  padding: 4rem 3.2rem;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background:
+      radial-gradient(ellipse at 20% 50%, rgba(26,122,76,0.15) 0%, transparent 50%),
+      radial-gradient(ellipse at 80% 30%, rgba(41,128,185,0.12) 0%, transparent 50%);
+    pointer-events: none;
+  }
+
+  > * { position: relative; z-index: 1; }
+
+  .aside-brand {
+    font-family: 'DM Serif Display', serif;
+    font-size: 1.25rem;
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+
+    .mark {
+      width: 32px;
+      height: 32px;
+      background: rgba(255,255,255,0.1);
+      border: 1px solid rgba(255,255,255,0.2);
+      border-radius: var(--radius);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.7rem;
+      font-weight: 700;
+    }
+  }
+
+  h1 {
+    font-family: 'DM Serif Display', serif;
+    font-weight: 400;
+    font-size: clamp(2rem, 3.8vw, 2.6rem);
+    line-height: 1.15;
+    max-width: 460px;
+    margin-bottom: 1.2rem;
+
+    em { font-style: italic; color: rgba(255,255,255,0.55); }
+  }
+
+  .blurb {
+    font-size: 0.95rem;
+    color: rgba(255,255,255,0.65);
+    max-width: 440px;
+    font-weight: 300;
+    line-height: 1.7;
+  }
+
+  .aside-foot { font-size: 0.74rem; color: rgba(255,255,255,0.45); font-weight: 300; }
+}
+
+.login-form-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 2rem;
+}
+
+.login-form {
+  width: 100%;
+  max-width: 380px;
+
+  .form-overline {
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--muted);
+    font-weight: 600;
+  }
+
+  h2 {
+    font-family: 'DM Serif Display', serif;
+    font-weight: 400;
+    font-size: 1.7rem;
+    margin: 0.3rem 0 0.4rem;
+  }
+
+  .lead {
+    color: var(--muted);
+    font-size: 0.9rem;
+    font-weight: 300;
+    margin-bottom: 2rem;
+  }
+
+  .form-field { margin-bottom: 1rem; }
+
+  .form-helper {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: -0.5rem;
+    margin-bottom: 1.2rem;
+    font-size: 0.78rem;
+    color: var(--muted);
+
+    label { display: flex; align-items: center; gap: 0.35rem; }
+    a { color: var(--penn-blue); font-weight: 600; &:hover { text-decoration: underline; } }
+  }
+
+  .btn { width: 100%; padding: 0.75rem; }
+
+  .or-divider {
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    margin: 1.3rem 0;
+    color: var(--muted);
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+
+    &::before, &::after { content: ''; flex: 1; height: 1px; background: rgba(0,0,0,0.08); }
+  }
+
+  .sso-btn {
+    width: 100%;
+    padding: 0.7rem;
+    border: 1.5px solid var(--line);
+    background: #fff;
+    border-radius: var(--radius);
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: #2b3a4a;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    cursor: pointer;
+    font-family: inherit;
+
+    &:hover { border-color: var(--penn-blue); color: var(--penn-blue); }
+  }
+
+  .login-error {
+    margin-bottom: 0.9rem;
+    padding: 0.65rem 0.9rem;
+    background: rgba(220, 50, 47, 0.06);
+    border: 1px solid rgba(220, 50, 47, 0.25);
+    border-radius: var(--radius);
+    font-size: 0.82rem;
+    color: #c0392b;
+    font-weight: 500;
+  }
+
+  .security-note {
+    margin-top: 2rem;
+    padding: 0.7rem 0.9rem;
+    background: rgba(1,31,91,0.04);
+    border-radius: var(--radius);
+    font-size: 0.74rem;
+    color: var(--muted);
+    font-weight: 300;
+    line-height: 1.5;
+    border-left: 3px solid var(--accent);
+  }
+
+  .demo-hint {
+    margin-top: 1rem;
+    padding: 0.7rem 0.9rem;
+    background: rgba(13,115,119,0.06);
+    border-radius: var(--radius);
+    font-size: 0.74rem;
+    color: var(--muted);
+    font-weight: 400;
+    line-height: 1.5;
+    border-left: 3px solid var(--teal);
+
+    strong { color: var(--teal); font-weight: 700; }
+  }
+}
+
+/* =========================================================
+   PI Sign page
+   ========================================================= */
+.sign-topbar {
+  background: var(--ink);
+  color: #fff;
+  padding: 0.7rem 1.4rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  font-size: 0.82rem;
+
+  .sign-brand {
+    font-family: 'DM Serif Display', serif;
+    font-size: 1.05rem;
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+
+    .mark {
+      width: 26px;
+      height: 26px;
+      background: rgba(255,255,255,0.12);
+      border: 1px solid rgba(255,255,255,0.18);
+      border-radius: var(--radius);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.6rem;
+      font-weight: 700;
+    }
+  }
+
+  .clerk-pill {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    background: rgba(255,255,255,0.08);
+    border: 1px solid rgba(255,255,255,0.14);
+    padding: 0.25rem 0.7rem;
+    border-radius: 100px;
+    font-size: 0.72rem;
+    color: rgba(255,255,255,0.85);
+  }
+}
+
+.sign-wrap {
+  max-width: 820px;
+  margin: 2.5rem auto;
+  padding: 0 1.5rem;
+}
+
+.sign-doc {
+  background: var(--card);
+  border-radius: var(--radius);
+  box-shadow: var(--card-shadow);
+  border: 1px solid rgba(0,0,0,0.04);
+  overflow: hidden;
+}
+
+.sign-doc-head {
+  padding: 1.2rem 1.8rem;
+  background: var(--cream);
+  border-bottom: 1px solid rgba(0,0,0,0.06);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+
+  h2 {
+    font-family: 'DM Serif Display', serif;
+    font-weight: 400;
+    font-size: 1.3rem;
+  }
+
+  .doc-meta { font-size: 0.74rem; color: var(--muted); font-family: 'JetBrains Mono', monospace; }
+}
+
+.sign-doc-body {
+  padding: 1.8rem;
+  font-size: 0.92rem;
+  color: #2d3640;
+  line-height: 1.75;
+  font-weight: 300;
+
+  h3 {
+    font-family: 'DM Serif Display', serif;
+    font-weight: 400;
+    font-size: 1.1rem;
+    margin: 1.2rem 0 0.4rem;
+    color: var(--ink);
+  }
+
+  .key-terms {
+    background: var(--cream);
+    border-radius: var(--radius);
+    padding: 1rem 1.2rem;
+    margin: 1.2rem 0;
+    border-left: 3px solid var(--accent);
+
+    .r {
+      display: flex;
+      justify-content: space-between;
+      padding: 0.18rem 0;
+      font-size: 0.85rem;
+
+      .l { color: var(--muted); }
+      .v { font-weight: 500; color: var(--ink); font-family: 'JetBrains Mono', monospace; font-size: 0.82rem; }
+    }
+  }
+
+  ol { margin: 0.6rem 0 0.6rem 1.4rem; li { padding: 0.15rem 0; } }
+}
+
+.sign-doc-foot {
+  padding: 1.6rem 1.8rem 1.8rem;
+  border-top: 1px solid rgba(0,0,0,0.05);
+  background: var(--paper);
+
+  .sign-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.6rem;
+    margin-bottom: 1.2rem;
+
+    @media (max-width: 700px) { grid-template-columns: 1fr; }
+  }
+}
+
+.sign-block {
+  .lbl-big {
+    font-size: 0.66rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--muted);
+    font-weight: 600;
+    margin-bottom: 0.55rem;
+  }
+}
+
+.sign-empty {
+  height: 90px;
+  border: 1.5px dashed var(--line);
+  border-radius: var(--radius);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255,255,255,0.4);
+  color: var(--muted);
+  font-style: italic;
+  font-size: 0.9rem;
+}
+
+.sign-counter-box {
+  background: var(--cream);
+  border-radius: var(--radius);
+  border: 1px solid rgba(0,0,0,0.06);
+  padding: 0.85rem 1.1rem;
+
+  .name { font-family: 'DM Serif Display', serif; font-size: 1.05rem; color: var(--ink); }
+  .role { font-size: 0.72rem; color: var(--muted); font-weight: 500; margin-top: 0.2rem; }
+  .note { font-size: 0.74rem; color: var(--muted); margin-top: 0.4rem; }
+}
+
+.sign-cta-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(0,0,0,0.05);
+  flex-wrap: wrap;
+
+  .legal { font-size: 0.74rem; color: var(--muted); font-weight: 300; max-width: 380px; line-height: 1.5; }
+
+  .cta-btns { display: flex; gap: 0.6rem; align-items: center; }
+
+  .btn-sign {
+    background: var(--penn-blue);
+    color: #fff;
+    border: none;
+    padding: 0.85rem 1.6rem;
+    border-radius: var(--radius);
+    font-weight: 600;
+    font-size: 0.92rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    font-family: inherit;
+    transition: background 0.2s;
+
+    &:hover { background: var(--penn-light-blue); }
+    &:disabled { opacity: 0.55; cursor: not-allowed; }
+  }
+
+  .btn-submit { background: var(--green); &:hover { background: var(--green-light); } }
+
+  .btn-back {
+    background: transparent;
+    color: var(--muted);
+    border: 1px solid var(--line);
+    padding: 0.85rem 1.4rem;
+    border-radius: var(--radius);
+    font-weight: 500;
+    cursor: pointer;
+    font-size: 0.88rem;
+    font-family: inherit;
+  }
+}
+
+.sign-confirm-card {
+  background: linear-gradient(135deg, rgba(26,122,76,0.06), rgba(26,122,76,0.02));
+  border-radius: var(--radius);
+  border: 1px solid rgba(26,122,76,0.2);
+  border-left: 3px solid var(--green);
+  padding: 1rem 1.3rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.4rem;
+
+  .check-circle {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: var(--green);
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: 1.1rem;
+    flex-shrink: 0;
+  }
+
+  h4 { font-size: 0.92rem; font-weight: 600; color: var(--green); }
+  p  { font-size: 0.82rem; color: #2b3a4a; font-weight: 300; }
+}
+
+/* Clerk modal */
+.clerk-overlay {
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(10,15,26,0.5);
+  backdrop-filter: blur(6px);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.clerk-modal {
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+  max-width: 420px;
+  width: 100%;
+  overflow: hidden;
+  animation: pop 0.18s ease-out;
+}
+
+@keyframes pop {
+  from { transform: scale(0.96); opacity: 0; }
+  to   { transform: scale(1);    opacity: 1; }
+}
+
+.clerk-modal .cm-head {
+  padding: 1.5rem 1.5rem 0.5rem;
+  text-align: center;
+
+  .clerk-brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.72rem;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-weight: 600;
+    margin-bottom: 0.8rem;
+  }
+
+  h3 {
+    font-family: 'DM Serif Display', serif;
+    font-weight: 400;
+    font-size: 1.4rem;
+    margin-bottom: 0.4rem;
+  }
+
+  .cm-lead { color: var(--muted); font-size: 0.88rem; font-weight: 300; margin-bottom: 1.2rem; }
+}
+
+.clerk-modal .cm-body {
+  padding: 0 1.5rem 1.5rem;
+
+  .cm-field { margin-bottom: 0.9rem; input { background: #fff; font-size: 0.9rem; } }
+
+  .cm-or {
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    margin: 1rem 0;
+    font-size: 0.7rem;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+
+    &::before, &::after { content: ''; flex: 1; height: 1px; background: rgba(0,0,0,0.08); }
+  }
+
+  .cm-oauth {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+
+    button {
+      padding: 0.65rem;
+      border: 1px solid var(--line);
+      background: #fff;
+      border-radius: var(--radius);
+      font-size: 0.82rem;
+      font-weight: 500;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.4rem;
+      font-family: inherit;
+
+      &:hover { border-color: var(--penn-blue); }
+    }
+  }
+
+  .btn-verify {
+    width: 100%;
+    background: var(--penn-blue);
+    color: #fff;
+    border: none;
+    padding: 0.75rem;
+    border-radius: var(--radius);
+    font-weight: 600;
+    font-size: 0.9rem;
+    cursor: pointer;
+    font-family: inherit;
+
+    &:hover { background: var(--penn-light-blue); }
+  }
+
+  .cm-legal {
+    text-align: center;
+    font-size: 0.7rem;
+    color: var(--muted);
+    margin-top: 0.85rem;
+    line-height: 1.5;
+  }
+}
+
+.clerk-modal .cm-foot {
+  background: var(--cream);
+  padding: 0.7rem 1.5rem;
+  text-align: center;
+  font-size: 0.7rem;
+  color: var(--muted);
+  border-top: 1px solid rgba(0,0,0,0.05);
+
+  strong { color: var(--ink); font-weight: 600; }
+}
+
+/* =========================================================
+   Study detail inline grid
+   ========================================================= */
+.study-info-grid {
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  gap: 0.6rem 1.4rem;
+  font-size: 0.86rem;
+  padding: 0.4rem 1.4rem 1.4rem;
+
+  .info-lbl {
+    color: var(--muted);
+    font-size: 0.74rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 600;
+  }
+}

--- a/layouts/admin.vue
+++ b/layouts/admin.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+import { useAdminStore } from '~/stores/admin'
+
+const adminStore = useAdminStore()
+const route = useRoute()
+
+const userMenuOpen = ref(false)
+
+function toggleUserMenu(e: Event) {
+  e.stopPropagation()
+  userMenuOpen.value = !userMenuOpen.value
+}
+
+function closeUserMenu() {
+  userMenuOpen.value = false
+}
+
+async function handleSignOut() {
+  closeUserMenu()
+  await adminStore.logout()
+  navigateTo('/admin/login')
+}
+
+function isActive(path: string) {
+  return route.path === path || route.path.startsWith(path + '/')
+}
+
+onMounted(async () => {
+  document.addEventListener('click', closeUserMenu)
+  if (!adminStore.isInitialized) {
+    await adminStore.loadAll()
+  }
+})
+
+onUnmounted(() => {
+  document.removeEventListener('click', closeUserMenu)
+})
+</script>
+
+<template>
+  <div class="admin-shell">
+    <!-- Top bar -->
+    <header class="admin-topbar">
+      <NuxtLink to="/admin" class="brand">
+        <div class="mark">I3H</div>
+        Immune Health
+      </NuxtLink>
+      <div class="scope-pill">Admin Console</div>
+      <div class="topbar-spacer" />
+      <div class="topbar-search">
+        <input type="search" placeholder="Search studies, PIs, IRBs, sample IDs…">
+      </div>
+      <NuxtLink to="/admin/communications" class="btn btn-ghost btn-sm">✉ Comms</NuxtLink>
+      <div class="user-pill" @click.stop="toggleUserMenu">
+        <div class="av">{{ adminStore.user.initials }}</div>
+        <div>
+          <div class="pill-name">{{ adminStore.user.name }}</div>
+          <div class="pill-role">{{ adminStore.user.role }}</div>
+        </div>
+        <span class="caret">▾</span>
+        <div v-if="userMenuOpen" class="user-menu" @click.stop>
+          <div class="who">
+            <div class="um-name">{{ adminStore.user.name }}</div>
+            <div class="um-email">{{ adminStore.user.email }}</div>
+            <div class="um-session">
+              <span class="dot" />
+              Active session · expires in 47 min
+            </div>
+          </div>
+          <button class="um-item" @click="closeUserMenu(); $emit('alert', 'Phase 2: account settings')">
+            <span class="ico">⚙</span> Account settings
+          </button>
+          <button class="um-item" @click="closeUserMenu(); $emit('alert', 'Phase 2: team management')">
+            <span class="ico">◐</span> Manage team access
+          </button>
+          <button class="um-item danger" @click="handleSignOut">
+            <span class="ico">⎋</span> Sign out
+          </button>
+        </div>
+      </div>
+    </header>
+
+    <!-- Shell: sidebar + main -->
+    <div class="admin-body">
+      <nav class="admin-sidebar">
+        <div class="sb-section">Operations</div>
+        <NuxtLink to="/admin" class="sb-link" :class="{ active: route.path === '/admin' }">
+          <span class="sb-ico">◆</span> Dashboard
+        </NuxtLink>
+        <NuxtLink to="/admin/inquiries" class="sb-link" :class="{ active: isActive('/admin/inquiries') }">
+          <span class="sb-ico">⌧</span> Inquiries
+          <span class="sb-count">{{ adminStore.newInquiriesCount }}</span>
+        </NuxtLink>
+        <NuxtLink to="/admin/studies" class="sb-link" :class="{ active: isActive('/admin/studies') }">
+          <span class="sb-ico">≡</span> Studies
+          <span class="sb-count">{{ adminStore.studies.length }}</span>
+        </NuxtLink>
+
+        <div class="sb-section">Records</div>
+        <button class="sb-link" @click="alert('Phase 2: Investigators directory')">
+          <span class="sb-ico">◐</span> Investigators
+        </button>
+        <button class="sb-link" @click="alert('Phase 2: Rate card management')">
+          <span class="sb-ico">$</span> Rate Card
+        </button>
+
+        <div class="sb-section">System</div>
+        <NuxtLink to="/admin/communications" class="sb-link" :class="{ active: isActive('/admin/communications') }">
+          <span class="sb-ico">✉</span> Communications
+        </NuxtLink>
+        <button class="sb-link" @click="alert('Phase 2: Settings & team access')">
+          <span class="sb-ico">⚙</span> Settings
+        </button>
+
+        <div class="sb-footer">
+          <div style="font-weight:600; color:#7f8c8d; margin-bottom:0.2rem;">Phase 1 MVP</div>
+          v0.4.0 · staging · last sync 4 min ago
+        </div>
+      </nav>
+
+      <main class="admin-main">
+        <slot />
+      </main>
+    </div>
+  </div>
+</template>

--- a/middleware/admin-auth.global.ts
+++ b/middleware/admin-auth.global.ts
@@ -1,0 +1,10 @@
+export default defineNuxtRouteMiddleware((to) => {
+  if (!to.path.startsWith('/admin')) return
+  if (to.path === '/admin/login') return
+  if (to.path.startsWith('/admin/sign/')) return
+
+  const user = useSupabaseUser()
+  if (!user.value) {
+    return navigateTo('/admin/login')
+  }
+})

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -5,11 +5,17 @@ export default defineNuxtConfig({
   modules: [
     '@pinia/nuxt',
     '@nuxt/eslint',
+    '@nuxtjs/supabase',
   ],
+
+  supabase: {
+    redirect: false,
+  },
 
   css: [
     '~/assets/css/main.scss',
     '~/assets/css/variables.scss',
+    '~/assets/css/admin.scss',
   ],
 
   app: {
@@ -24,7 +30,7 @@ export default defineNuxtConfig({
         { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' },
         {
           rel: 'stylesheet',
-          href: 'https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=Source+Sans+3:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap'
+          href: 'https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=Source+Sans+3:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Dancing+Script:wght@600;700&display=swap'
         },
       ],
     },
@@ -32,6 +38,7 @@ export default defineNuxtConfig({
 
   runtimeConfig: {
     // Private keys (server-side only)
+    signingSecret: process.env.SIGNING_SECRET || '',
     mailersendApiKey: process.env.MAILERSEND_API_TOKEN || '',
     mailersendFromEmail: process.env.MAILERSEND_FROM_EMAIL || 'noreply@test-q3enl6k3n8042vwr.mlsender.net',
     mailersendFromName: process.env.MAILERSEND_FROM_NAME || 'Immune Health Portal',

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@contentful/rich-text-html-renderer": "^16.6.9",
+    "@nuxtjs/supabase": "^2.0.7",
     "@pinia/nuxt": "^0.5.5",
     "aws-amplify": "^6.6.7",
     "contentful": "^10.15.2",

--- a/pages/admin/communications.vue
+++ b/pages/admin/communications.vue
@@ -1,0 +1,128 @@
+<script setup lang="ts">
+definePageMeta({ layout: 'admin' })
+</script>
+
+<template>
+  <div>
+    <div class="page-hd">
+      <div>
+        <h1>Communications</h1>
+        <div class="sub">Transactional emails triggered by the platform. Phase 1: two confirmation emails on intake submission.</div>
+      </div>
+      <div class="hd-actions">
+        <button class="btn btn-secondary btn-sm">View MailerSend log</button>
+      </div>
+    </div>
+
+    <div class="assume-banner">
+      <strong>Phase 1 scope</strong>
+      When a PI submits the intake form, two MailerSend emails fire automatically — one to the PI confirming receipt,
+      one to I3H staff with a summary + a deep link into the inquiry queue. Both render below.
+    </div>
+
+    <div class="email-grid">
+      <!-- PI confirmation -->
+      <div class="email-card">
+        <div class="email-head">
+          <h4>PI confirmation</h4>
+          <span class="etag">Auto · on intake submit</span>
+        </div>
+        <div class="email-meta">
+          <div><span class="l">From: </span><span class="v">Immune Health &lt;noreply@immunehealth.science&gt;</span></div>
+          <div><span class="l">To: </span><span class="v">&#123;&#123; pi.email &#125;&#125;</span></div>
+          <div><span class="l">Cc: </span><span class="v">&#123;&#123; studyLead.email &#125;&#125;</span></div>
+          <div><span class="l">Subject: </span><span class="v">We've received your I3H study inquiry — &#123;&#123; study.name &#125;&#125;</span></div>
+        </div>
+        <div class="email-body">
+          <div class="em-brand-row">
+            <div class="mark">I3H</div>
+            <div class="name">Immune Health</div>
+          </div>
+
+          <h3>Thanks, Dr. Katona — we've received your inquiry.</h3>
+
+          <p>Your study request for <strong>BHB ColCan</strong> has been submitted to the Institute for Immunology &amp; Immune Health. A member of our team will review feasibility and reach out within <strong>3 business days</strong> with next steps.</p>
+
+          <div class="em-summary">
+            <div class="r"><span class="l">Study</span><span class="v">BHB ColCan (BHB)</span></div>
+            <div class="r"><span class="l">Principal Investigator</span><span class="v">Dr. Katona</span></div>
+            <div class="r"><span class="l">Cohort scope</span><span class="v">20 subjects × 2 timepoints = 40 samples</span></div>
+            <div class="r"><span class="l">Services requested</span><span class="v">PBMC, CyTOF MDIPA, Tier 1</span></div>
+            <div class="r"><span class="l">Estimated total</span><span class="v">$27,250 (Penn internal rates)</span></div>
+          </div>
+
+          <p><strong>What happens next:</strong></p>
+          <p style="margin:0.6rem 0 1rem 0;">
+            1. I3H staff review feasibility and capacity.<br>
+            2. If approved, you'll receive an agreement package (User Agreement, Rate Schedule, LabVantage form, Pennsieve agreement).<br>
+            3. Once countersigned, your study is activated and we begin scheduling.
+          </p>
+
+          <span class="em-cta">View your inquiry status</span>
+
+          <p class="em-signoff">
+            Questions in the meantime? Reply to this email or reach out to<br>
+            <strong>Lori Guercio</strong> · <span class="mono">lguercio@pennmedicine.upenn.edu</span>
+          </p>
+
+          <div class="em-legal">
+            Institute for Immunology &amp; Immune Health · Perelman School of Medicine, University of Pennsylvania · 421 Curie Boulevard, Philadelphia, PA 19104.
+            This message contains research operations information and is intended for the named recipient.
+          </div>
+        </div>
+      </div>
+
+      <!-- Staff alert -->
+      <div class="email-card">
+        <div class="email-head">
+          <h4>I3H staff alert</h4>
+          <span class="etag">Auto · on intake submit</span>
+        </div>
+        <div class="email-meta">
+          <div><span class="l">From: </span><span class="v">Immune Health Platform &lt;noreply@immunehealth.science&gt;</span></div>
+          <div><span class="l">To: </span><span class="v">intake@immunehealth.science</span></div>
+          <div><span class="l">Cc: </span><span class="v">lguercio@pennmedicine.upenn.edu, khas@pennmedicine.upenn.edu</span></div>
+          <div><span class="l">Subject: </span><span class="v">🆕 New inquiry — BHB ColCan · Dr. Katona · Internal</span></div>
+        </div>
+        <div class="email-body">
+          <div class="em-brand-row">
+            <div class="mark">I3H</div>
+            <div class="name">Admin Console</div>
+          </div>
+
+          <h3>New study inquiry submitted</h3>
+
+          <p style="font-size:0.86rem"><strong>BHB ColCan</strong> was just submitted by <strong>Dr. Katona</strong> (Penn Internal · Gastroenterology). Quick summary below — full intake is available in the console.</p>
+
+          <div class="em-summary">
+            <div class="r"><span class="l">Submitted</span><span class="v">May 12, 2026 · 11:02 AM</span></div>
+            <div class="r"><span class="l">PI</span><span class="v">Dr. Katona · katona@pennmedicine.upenn.edu</span></div>
+            <div class="r"><span class="l">Study lead</span><span class="v">John Smith · jsmith@pennmedicine.upenn.edu</span></div>
+            <div class="r"><span class="l">Affiliation</span><span class="v">Penn Internal</span></div>
+            <div class="r"><span class="l">IRB</span><span class="v">850567</span></div>
+            <div class="r"><span class="l">Scope</span><span class="v">20 × 2 = 40 samples · fresh blood</span></div>
+            <div class="r"><span class="l">Services</span><span class="v">PBMC, CyTOF MDIPA, Tier 1</span></div>
+            <div class="r"><span class="l">Est. revenue</span><span class="v">$27,250</span></div>
+            <div class="r"><span class="l">Budget code</span><span class="v">400-4661-1-605016-…-2459-0000</span></div>
+          </div>
+
+          <p style="font-size:0.86rem; margin:0.8rem 0 0"><strong>Objectives (PI's words):</strong></p>
+          <p style="font-size:0.85rem; font-style:italic; color:#555; margin-bottom:1rem">
+            "Investigation of beta-hydroxybutyrate (BHB) supplementation as a chemopreventive intervention for colorectal cancer.
+            Quantify shifts in immune cell composition at baseline and 4 weeks post-supplementation."
+          </p>
+
+          <span class="em-cta">Open in Admin Console →</span>
+
+          <p class="em-signoff" style="font-size:0.8rem">
+            This is an automated alert from the Immune Health platform. Inquiry status, notes, and the full intake form are available in the console.
+          </p>
+
+          <div class="em-legal">
+            Sent automatically by the I3H platform via MailerSend. To adjust who receives intake alerts, update the admin notification list in Settings.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/pages/admin/index.vue
+++ b/pages/admin/index.vue
@@ -1,0 +1,226 @@
+<script setup lang="ts">
+import { useAdminStore } from '~/stores/admin'
+
+definePageMeta({ layout: 'admin' })
+
+const adminStore = useAdminStore()
+</script>
+
+<template>
+  <div>
+    <div class="page-hd">
+      <div>
+        <h1>Good afternoon, Lori.</h1>
+        <div class="sub">Wednesday, May 12, 2026 · {{ adminStore.studies.length }} active studies across the platform</div>
+      </div>
+      <div class="hd-actions">
+        <button class="btn btn-secondary btn-sm">↻ Refresh</button>
+        <NuxtLink to="/admin/inquiries" class="btn btn-primary btn-sm">
+          Review {{ adminStore.newInquiriesCount }} inquiries →
+        </NuxtLink>
+      </div>
+    </div>
+
+    <div class="assume-banner">
+      <strong>Design note — mockup data</strong>
+      All numbers are illustrative. The Dashboard reads from
+      <span class="mono">studies</span>, <span class="mono">agreements</span>,
+      <span class="mono">samples</span>, and <span class="mono">processing_events</span>.
+      KPIs update on intake submission and every processing event log.
+    </div>
+
+    <!-- KPI tiles -->
+    <div class="kpi-grid">
+      <div class="kpi-card">
+        <div class="kpi-lbl">Active studies</div>
+        <div class="kpi-val">14</div>
+        <div class="kpi-ctx"><span class="delta-up">+2</span> this month</div>
+      </div>
+      <div class="kpi-card warn">
+        <div class="kpi-lbl">Pending review</div>
+        <div class="kpi-val">4</div>
+        <div class="kpi-ctx">Oldest: 6 days ·
+          <NuxtLink to="/admin/inquiries" class="alert-act" style="font-size:0.74rem; color:var(--penn-blue); font-weight:600; text-decoration:none; &:hover{text-decoration:underline}">Review queue</NuxtLink>
+        </div>
+      </div>
+      <div class="kpi-card">
+        <div class="kpi-lbl">Awaiting signature</div>
+        <div class="kpi-val">7</div>
+        <div class="kpi-ctx">across 3 studies · 1 overdue</div>
+      </div>
+      <div class="kpi-card">
+        <div class="kpi-lbl">Samples processed (YTD)</div>
+        <div class="kpi-val">412</div>
+        <div class="kpi-ctx"><span class="delta-up">+38</span> last 30 days</div>
+      </div>
+    </div>
+
+    <!-- Alerts -->
+    <div class="alerts-strip">
+      <div class="alert-row error">
+        <span class="adm-badge b-warn"><span class="dot" /> Overdue</span>
+        <span><strong>BHB ColCan</strong> — User Agreement sent 11 days ago, no signature.</span>
+        <span class="alert-meta">May 01</span>
+        <NuxtLink to="/admin/studies/bhb-colcan" class="alert-act">Open study →</NuxtLink>
+      </div>
+      <div class="alert-row">
+        <span class="adm-badge b-review"><span class="dot" /> Needs Action</span>
+        <span>4 new intake submissions are awaiting feasibility review.</span>
+        <span class="alert-meta">today</span>
+        <NuxtLink to="/admin/inquiries" class="alert-act">Open queue →</NuxtLink>
+      </div>
+      <div class="alert-row info">
+        <span class="adm-badge b-internal"><span class="dot" /> FYI</span>
+        <span>PRINCE-Val processing run scheduled tomorrow. 12 samples in batch.</span>
+        <span class="alert-meta">May 13</span>
+        <NuxtLink to="/admin/studies/prince-val" class="alert-act">View schedule →</NuxtLink>
+      </div>
+    </div>
+
+    <!-- Two-column -->
+    <div class="dash-cols">
+      <!-- Recent activity -->
+      <div class="panel">
+        <div class="panel-head">
+          <h3>Recent activity</h3>
+          <span class="ctx">Last 7 days</span>
+        </div>
+        <div class="panel-body">
+          <div class="panel-row">
+            <div>
+              <div class="row-pri">Agreement signed — Rate Schedule</div>
+              <div class="row-sec">SURGE-Christie · Dr. Christie countersigned</div>
+            </div>
+            <div class="row-right">
+              <span class="adm-badge b-complete"><span class="dot" /> Signed</span>
+              <span class="row-when">2h ago</span>
+            </div>
+          </div>
+          <div class="panel-row">
+            <div>
+              <div class="row-pri">New intake submitted</div>
+              <div class="row-sec">APEX-Merck · Dr. Wilson · industry</div>
+            </div>
+            <div class="row-right">
+              <span class="adm-badge b-review"><span class="dot" /> Review</span>
+              <span class="row-when">4h ago</span>
+            </div>
+          </div>
+          <div class="panel-row">
+            <div>
+              <div class="row-pri">14 processing events logged</div>
+              <div class="row-sec">TITAN-Harvard · CyTOF acquisition batch #B-2026-018</div>
+            </div>
+            <div class="row-right">
+              <span class="adm-badge b-processing"><span class="dot" /> Processing</span>
+              <span class="row-when">yesterday</span>
+            </div>
+          </div>
+          <div class="panel-row">
+            <div>
+              <div class="row-pri">Samples received</div>
+              <div class="row-sec">PRINCE-Val · 12 PBMC vials, drop-off 9:15 AM</div>
+            </div>
+            <div class="row-right">
+              <span class="adm-badge b-internal"><span class="dot" /> Drop-off</span>
+              <span class="row-when">2d ago</span>
+            </div>
+          </div>
+          <div class="panel-row">
+            <div>
+              <div class="row-pri">Pennsieve dataset linked</div>
+              <div class="row-sec">TITAN-Harvard · N:dataset:0a83…cc11</div>
+            </div>
+            <div class="row-right">
+              <span class="adm-badge b-complete"><span class="dot" /> Linked</span>
+              <span class="row-when">3d ago</span>
+            </div>
+          </div>
+          <div class="panel-row">
+            <div>
+              <div class="row-pri">Agreement countersigned</div>
+              <div class="row-sec">PRINCE-Val · LabVantage Form · PI notified</div>
+            </div>
+            <div class="row-right">
+              <span class="adm-badge b-complete"><span class="dot" /> Signed</span>
+              <span class="row-when">4d ago</span>
+            </div>
+          </div>
+        </div>
+        <div class="panel-foot">
+          <span class="ctx">Showing 6 of 47 events</span>
+          <button class="link-btn">View activity log →</button>
+        </div>
+      </div>
+
+      <!-- Right column -->
+      <div style="display:flex; flex-direction:column; gap:1.2rem;">
+        <div class="panel">
+          <div class="panel-head"><h3>Studies by stage</h3></div>
+          <div class="panel-body">
+            <div class="panel-row">
+              <div><div class="row-pri">Intake review</div><div class="row-sec">awaiting feasibility</div></div>
+              <div class="row-right">
+                <span class="mono" style="font-size:1.1rem; font-weight:500; color:var(--gold)">4</span>
+              </div>
+            </div>
+            <div class="panel-row">
+              <div><div class="row-pri">Agreements out</div><div class="row-sec">awaiting PI signature</div></div>
+              <div class="row-right">
+                <span class="mono" style="font-size:1.1rem; font-weight:500; color:var(--teal)">3</span>
+              </div>
+            </div>
+            <div class="panel-row">
+              <div><div class="row-pri">Active processing</div><div class="row-sec">samples being run</div></div>
+              <div class="row-right">
+                <span class="mono" style="font-size:1.1rem; font-weight:500; color:var(--accent)">7</span>
+              </div>
+            </div>
+            <div class="panel-row">
+              <div><div class="row-pri">Data delivery</div><div class="row-sec">on Pennsieve, complete</div></div>
+              <div class="row-right">
+                <span class="mono" style="font-size:1.1rem; font-weight:500; color:var(--green)">4</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-head">
+            <h3>Processing throughput</h3>
+            <span class="ctx">Samples / week</span>
+          </div>
+          <div class="panel-body" style="padding:1rem 1.4rem 1.4rem">
+            <svg viewBox="0 0 320 110" style="width:100%; height:130px;">
+              <defs>
+                <linearGradient id="bgrad" x1="0" x2="0" y1="0" y2="1">
+                  <stop offset="0%" stop-color="#011f5b" stop-opacity="0.85" />
+                  <stop offset="100%" stop-color="#011f5b" stop-opacity="0.4" />
+                </linearGradient>
+              </defs>
+              <line x1="0" y1="30" x2="320" y2="30" stroke="#000" stroke-opacity="0.05" />
+              <line x1="0" y1="60" x2="320" y2="60" stroke="#000" stroke-opacity="0.05" />
+              <line x1="0" y1="90" x2="320" y2="90" stroke="#000" stroke-opacity="0.05" />
+              <rect x="10"  y="55" width="22" height="40" rx="2" fill="url(#bgrad)" />
+              <rect x="44"  y="38" width="22" height="57" rx="2" fill="url(#bgrad)" />
+              <rect x="78"  y="62" width="22" height="33" rx="2" fill="url(#bgrad)" />
+              <rect x="112" y="22" width="22" height="73" rx="2" fill="url(#bgrad)" />
+              <rect x="146" y="48" width="22" height="47" rx="2" fill="url(#bgrad)" />
+              <rect x="180" y="10" width="22" height="85" rx="2" fill="url(#bgrad)" />
+              <rect x="214" y="28" width="22" height="67" rx="2" fill="url(#bgrad)" />
+              <rect x="248" y="18" width="22" height="77" rx="2" fill="#0d7377" />
+              <rect x="282" y="40" width="22" height="55" rx="2" fill="#0d7377" fill-opacity="0.5" />
+              <line x1="0" y1="95" x2="320" y2="95" stroke="#000" stroke-opacity="0.15" />
+            </svg>
+            <div style="display:flex; justify-content:space-between; font-size:0.65rem; color:var(--muted); font-family:'JetBrains Mono',monospace; margin-top:0.3rem;">
+              <span>W11</span><span>W12</span><span>W13</span><span>W14</span><span>W15</span><span>W16</span><span>W17</span><span>W18</span><span>this</span>
+            </div>
+            <div style="margin-top:0.7rem; font-size:0.78rem; color:var(--muted);">
+              Avg <strong style="color:var(--ink)">38/wk</strong> · Peak <strong style="color:var(--ink)">62</strong> (W16)
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/pages/admin/inquiries/[id].vue
+++ b/pages/admin/inquiries/[id].vue
@@ -1,0 +1,216 @@
+<script setup lang="ts">
+import { useAdminStore } from '~/stores/admin'
+
+definePageMeta({ layout: 'admin' })
+
+const route = useRoute()
+const adminStore = useAdminStore()
+
+const inquiry = computed(() => adminStore.inquiries.find(i => i.id === route.params.id))
+
+if (!inquiry.value) {
+  navigateTo('/admin/inquiries')
+}
+
+const affiliationClass = computed(() => {
+  if (!inquiry.value) return ''
+  if (inquiry.value.affiliation === 'Internal') return 'b-internal'
+  if (inquiry.value.affiliation === 'External') return 'b-external'
+  return 'b-industry'
+})
+
+const isApproving = ref(false)
+const isDeclining = ref(false)
+
+async function approveAndSend() {
+  if (!inquiry.value) return
+  isApproving.value = true
+  try {
+    const { studyId } = await $fetch('/api/admin/approve-inquiry', {
+      method: 'POST',
+      body: { inquiryId: inquiry.value.id },
+    }) as { studyId: string }
+    await adminStore.loadAll()
+    navigateTo(`/admin/studies/${studyId}`)
+  }
+  catch {
+    alert('Failed to approve inquiry. Please try again.')
+  }
+  finally {
+    isApproving.value = false
+  }
+}
+
+async function decline() {
+  if (!inquiry.value) return
+  if (!confirm(`Decline inquiry from ${inquiry.value.pi.name}? This cannot be undone.`)) return
+  isDeclining.value = true
+  try {
+    await $fetch('/api/admin/decline-inquiry', {
+      method: 'POST',
+      body: { inquiryId: inquiry.value.id },
+    })
+    await adminStore.loadAll()
+    navigateTo('/admin/inquiries')
+  }
+  catch {
+    alert('Failed to decline inquiry. Please try again.')
+  }
+  finally {
+    isDeclining.value = false
+  }
+}
+</script>
+
+<template>
+  <div v-if="inquiry">
+    <div class="crumbs">
+      <NuxtLink to="/admin/inquiries" class="crumb-link">Inquiries</NuxtLink>
+      <span class="sep">›</span>
+      <span>{{ inquiry.studyName }} · {{ inquiry.pi.name }}</span>
+    </div>
+
+    <!-- Hero -->
+    <div class="detail-hero">
+      <div>
+        <h2>
+          {{ inquiry.studyName }}
+          <span class="acronym">{{ inquiry.abbreviation }}</span>
+          <span class="adm-badge" :class="affiliationClass">
+            <span class="dot" /> {{ inquiry.affiliation }}
+          </span>
+          <span class="adm-badge b-review">
+            <span class="dot" /> Awaiting feasibility
+          </span>
+        </h2>
+        <div class="pi-line">
+          <strong>{{ inquiry.pi.name }}</strong> · {{ inquiry.affiliationOrg }} ·
+          <span class="mono">{{ inquiry.pi.email }}</span>
+        </div>
+        <div class="meta-strip">
+          <div class="meta-item">
+            <span class="meta-label">Submitted</span>
+            <span class="meta-val">{{ inquiry.submittedDate }} · {{ inquiry.submittedRelative }}</span>
+          </div>
+          <div class="meta-item">
+            <span class="meta-label">IRB</span>
+            <span class="meta-val">{{ inquiry.irb }}</span>
+          </div>
+          <div class="meta-item">
+            <span class="meta-label">Cohort scope</span>
+            <span class="meta-val">{{ inquiry.cohortSubjects }} subjects × {{ inquiry.cohortTimepoints }} timepoints = {{ inquiry.cohortSubjects * inquiry.cohortTimepoints }}</span>
+          </div>
+          <div v-if="inquiry.estimate" class="meta-item">
+            <span class="meta-label">Estimate</span>
+            <span class="meta-val">${{ inquiry.estimate.toLocaleString() }}</span>
+          </div>
+          <div v-if="inquiry.sampleType" class="meta-item">
+            <span class="meta-label">Sample type</span>
+            <span class="meta-val">{{ inquiry.sampleType }}</span>
+          </div>
+        </div>
+      </div>
+      <div class="hero-actions">
+        <button
+          class="btn btn-primary"
+          :disabled="isApproving || isDeclining || inquiry.status === 'Approved' || inquiry.status === 'Declined'"
+          @click="approveAndSend"
+        >
+          {{ isApproving ? 'Approving…' : 'Approve &amp; send agreement →' }}
+        </button>
+        <button class="btn btn-secondary btn-sm" :disabled="isApproving || isDeclining">Request more info</button>
+        <button
+          class="btn btn-ghost btn-sm"
+          style="color:var(--warm)"
+          :disabled="isApproving || isDeclining || inquiry.status === 'Approved' || inquiry.status === 'Declined'"
+          @click="decline"
+        >
+          {{ isDeclining ? 'Declining…' : 'Decline' }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Two-column -->
+    <div class="dt-grid">
+      <!-- Intake snapshot -->
+      <div class="panel">
+        <div class="panel-head">
+          <h3>Intake submission</h3>
+          <span class="ctx">Read-only · submitted via /intake</span>
+        </div>
+        <div class="study-info-grid">
+          <div class="info-lbl">Study objectives</div>
+          <div>{{ inquiry.objectives }}</div>
+
+          <template v-if="inquiry.studyLead">
+            <div class="info-lbl">Project lead</div>
+            <div>{{ inquiry.studyLead.name }} · <span class="mono">{{ inquiry.studyLead.email }}</span></div>
+          </template>
+
+          <template v-if="inquiry.phlebotomy">
+            <div class="info-lbl">Phlebotomy</div>
+            <div>{{ inquiry.phlebotomy }}</div>
+          </template>
+
+          <template v-if="inquiry.metadata">
+            <div class="info-lbl">Metadata plan</div>
+            <div>{{ inquiry.metadata }}</div>
+          </template>
+
+          <div class="info-lbl">Services</div>
+          <div>
+            <div v-for="svc in inquiry.servicesDetail" :key="svc.name">
+              {{ svc.name }} × {{ svc.qty }} — <span class="mono">{{ svc.rate }}</span>
+            </div>
+          </div>
+
+          <div class="info-lbl">Affiliation</div>
+          <div>
+            {{ inquiry.affiliation }} — {{ inquiry.affiliationOrg }}
+          </div>
+        </div>
+      </div>
+
+      <!-- Right column -->
+      <div style="display:flex; flex-direction:column; gap:1.2rem;">
+        <div class="panel">
+          <div class="panel-head"><h3>Feasibility checklist</h3></div>
+          <div style="padding:0.4rem 1.4rem 1.2rem; font-size:0.86rem;">
+            <label
+              v-for="item in inquiry.feasibility"
+              :key="item.label"
+              style="display:flex; align-items:center; gap:0.6rem; padding:0.45rem 0;"
+            >
+              <input type="checkbox" :checked="item.checked">
+              {{ item.label }}
+            </label>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-head"><h3>Reviewer notes</h3></div>
+          <div v-if="inquiry.notes.length" class="activity-timeline">
+            <div v-for="note in inquiry.notes" :key="note.date" class="t-item">
+              <div class="t-dot m" />
+              <div class="t-body">
+                <div class="t-title">{{ note.author }}</div>
+                <div class="t-meta">{{ note.date }}</div>
+                <div class="t-note">{{ note.text }}</div>
+              </div>
+            </div>
+          </div>
+          <div v-else style="padding:0.8rem 1.4rem; font-size:0.84rem; color:var(--muted)">
+            No notes yet.
+          </div>
+          <div class="note-composer">
+            <textarea placeholder="Add an internal note (visible only to I3H staff)…" />
+            <div class="composer-actions">
+              <button class="btn btn-secondary btn-sm">Cancel</button>
+              <button class="btn btn-primary btn-sm">Post note</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/pages/admin/inquiries/index.vue
+++ b/pages/admin/inquiries/index.vue
@@ -1,0 +1,138 @@
+<script setup lang="ts">
+import { useAdminStore } from '~/stores/admin'
+
+definePageMeta({ layout: 'admin' })
+
+const adminStore = useAdminStore()
+const activeFilter = ref('New')
+const searchQuery = ref('')
+
+const filters = [
+  { label: 'New', count: 4 },
+  { label: 'In Review', count: 2 },
+  { label: 'Approved', count: 8 },
+  { label: 'Declined', count: 1 },
+  { label: 'All', count: 15 },
+]
+
+const affiliationLabel = (aff: string) => {
+  if (aff === 'Internal') return 'b-internal'
+  if (aff === 'External') return 'b-external'
+  return 'b-industry'
+}
+
+const statusLabel = (status: string) => {
+  if (status === 'Stale') return 'b-warn'
+  return 'b-review'
+}
+
+const displayedInquiries = computed(() => {
+  let list = adminStore.inquiries
+  if (searchQuery.value) {
+    const q = searchQuery.value.toLowerCase()
+    list = list.filter(i =>
+      i.studyName.toLowerCase().includes(q) ||
+      i.pi.name.toLowerCase().includes(q) ||
+      i.irb.toLowerCase().includes(q)
+    )
+  }
+  return list
+})
+</script>
+
+<template>
+  <div>
+    <div class="page-hd">
+      <div>
+        <h1>Intake inquiries</h1>
+        <div class="sub">New study requests submitted via the public intake form. Review feasibility, then approve to begin the agreement package.</div>
+      </div>
+      <div class="hd-actions">
+        <button class="btn btn-secondary btn-sm">Export CSV</button>
+      </div>
+    </div>
+
+    <div class="toolbar">
+      <div class="chip-group">
+        <button
+          v-for="f in filters"
+          :key="f.label"
+          class="chip"
+          :class="{ active: activeFilter === f.label }"
+          @click="activeFilter = f.label"
+        >
+          {{ f.label }} <span class="chip-count">{{ f.count }}</span>
+        </button>
+      </div>
+      <div class="toolbar-search">
+        <input v-model="searchQuery" type="search" placeholder="Search by PI, study, or IRB…">
+      </div>
+      <div class="toolbar-spacer" />
+      <button class="btn btn-ghost btn-sm">Sort: Newest ↓</button>
+    </div>
+
+    <div class="table-wrap">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>Submitted</th>
+            <th>Study</th>
+            <th>Principal Investigator</th>
+            <th>Affiliation</th>
+            <th>Scope</th>
+            <th>Services requested</th>
+            <th>Status</th>
+            <th />
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="inquiry in displayedInquiries"
+            :key="inquiry.id"
+            @click="navigateTo('/admin/inquiries/' + inquiry.id)"
+          >
+            <td>
+              <div class="mono" style="font-size:0.78rem">{{ inquiry.submittedDate }}</div>
+              <div class="study-pi" :style="inquiry.isStale ? 'color:var(--warm)' : ''">
+                {{ inquiry.submittedRelative }}
+              </div>
+            </td>
+            <td>
+              <div class="study-name">{{ inquiry.studyName }}</div>
+              <div class="study-pi">{{ inquiry.objectives.substring(0, 50) }}… · IRB {{ inquiry.irb }}</div>
+            </td>
+            <td>
+              <div>{{ inquiry.pi.name }}</div>
+              <div class="study-pi">{{ inquiry.pi.email }}</div>
+            </td>
+            <td>
+              <span class="adm-badge" :class="affiliationLabel(inquiry.affiliation)">
+                <span class="dot" /> {{ inquiry.affiliation }}
+              </span>
+            </td>
+            <td class="mono" style="font-size:0.82rem">
+              {{ inquiry.cohortSubjects }} × {{ inquiry.cohortTimepoints }} = {{ inquiry.cohortSubjects * inquiry.cohortTimepoints }}
+            </td>
+            <td style="font-size:0.78rem; color:var(--muted)">{{ inquiry.services }}</td>
+            <td>
+              <span class="adm-badge" :class="statusLabel(inquiry.status)">
+                <span class="dot" /> {{ inquiry.status === 'New' ? 'Awaiting Review' : inquiry.status }}
+              </span>
+            </td>
+            <td style="text-align:right">
+              <span class="mono" style="color:var(--muted)">→</span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="pagination">
+        <span>Showing {{ displayedInquiries.length }} of {{ displayedInquiries.length }} new inquiries</span>
+        <div class="pag-controls">
+          <button>‹</button>
+          <button class="active">1</button>
+          <button>›</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/pages/admin/login.vue
+++ b/pages/admin/login.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+definePageMeta({ layout: false })
+
+const supabase = useSupabaseClient()
+const user = useSupabaseUser()
+
+const email = ref('')
+const password = ref('')
+const errorMessage = ref('')
+const isLoading = ref(false)
+
+onMounted(() => {
+  if (user.value) navigateTo('/admin')
+})
+
+async function handleSignIn() {
+  errorMessage.value = ''
+  isLoading.value = true
+  try {
+    const { error } = await supabase.auth.signInWithPassword({
+      email: email.value,
+      password: password.value,
+    })
+    if (error) {
+      errorMessage.value = error.message
+    }
+    else {
+      await navigateTo('/admin')
+    }
+  }
+  finally {
+    isLoading.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="login-shell">
+    <!-- Left: brand panel -->
+    <aside class="login-aside">
+      <div class="aside-brand">
+        <div class="mark">I3H</div>
+        <span>Immune Health</span>
+      </div>
+
+      <div>
+        <h1>The coordination layer for <em>standardized immune profiling.</em></h1>
+        <p class="blurb">
+          Manage study intake, agreements, sample processing, and cohort progress in one
+          place — the operations hub for the Institute for Immunology &amp; Immune Health.
+        </p>
+      </div>
+
+      <div class="aside-foot">
+        Penn Medicine · Institute for Immunology &amp; Immune Health<br>
+        Internal staff access only. PI communications happen via email.
+      </div>
+    </aside>
+
+    <!-- Right: form -->
+    <div class="login-form-wrap">
+      <form class="login-form" @submit.prevent="handleSignIn">
+        <span class="form-overline">Admin Console</span>
+        <h2>Sign in</h2>
+        <p class="lead">Restricted to authorized I3H staff. Credentials managed via Supabase Auth.</p>
+
+        <div class="form-field">
+          <label class="lbl">Work email</label>
+          <input v-model="email" type="email" placeholder="name@pennmedicine.upenn.edu" autocomplete="email">
+        </div>
+
+        <div class="form-field">
+          <label class="lbl">Password</label>
+          <input v-model="password" type="password" placeholder="••••••••" autocomplete="current-password">
+        </div>
+
+        <div class="form-helper">
+          <label><input type="checkbox" checked> Keep me signed in</label>
+          <a href="#" @click.prevent>Forgot password?</a>
+        </div>
+
+        <div v-if="errorMessage" class="login-error">{{ errorMessage }}</div>
+
+        <button class="btn btn-primary" type="submit" :disabled="isLoading">
+          {{ isLoading ? 'Signing in…' : 'Sign in to Admin Console' }}
+        </button>
+
+        <div class="security-note">
+          <strong style="color:var(--accent); font-weight:600;">Secure session.</strong>
+          This system contains protected research data. All activity is logged.
+          Sessions expire after 60 minutes of inactivity.
+        </div>
+      </form>
+    </div>
+  </div>
+</template>

--- a/pages/admin/sign/[token].vue
+++ b/pages/admin/sign/[token].vue
@@ -1,0 +1,287 @@
+<script setup lang="ts">
+definePageMeta({ layout: false })
+
+const route = useRoute()
+
+// URL path segment: {studyId}-{agreementId}  e.g. "bhb-colcan-psa"
+const token = computed(() => route.params.token as string)
+// JWT from query string — present when PI arrives via emailed link
+const signToken = computed(() => route.query.token as string | undefined)
+const isPreview = computed(() => !signToken.value)
+
+const studyId = computed(() => {
+  const parts = token.value.split('-')
+  return parts.slice(0, -1).join('-')
+})
+
+const agreementId = computed(() => {
+  const parts = token.value.split('-')
+  return parts[parts.length - 1]
+})
+
+// Fetch study + agreement details from Supabase using the service route
+// (sign page is public — no admin auth required)
+const { data: studyRow } = await useAsyncData(`sign-study-${studyId.value}`, async () => {
+  const supabase = useSupabaseClient()
+  const { data } = await supabase
+    .from('studies')
+    .select('name, abbreviation, irb, pi, affiliation_org, cohort, budget, agreements(*)')
+    .eq('id', studyId.value)
+    .single()
+  return data
+})
+
+const study = computed(() => studyRow.value)
+
+const agreement = computed(() => {
+  if (!study.value) return null
+  const agr = (study.value.agreements as Array<Record<string, unknown>>)
+  return agr.find(a => a.id === agreementId.value)
+    || agr.find(a => a.status === 'Pending')
+    || agr[agr.length - 1]
+})
+
+const showClerkModal = ref(false)
+const isSigned = ref(false)
+const isSubmitted = ref(false)
+const isSubmitting = ref(false)
+const signerName = ref('')
+const signerEmail = ref('')
+
+function openClerk() {
+  const pi = study.value?.pi as { name: string; email: string } | undefined
+  signerName.value = pi?.name.replace('Dr. ', '') || ''
+  signerEmail.value = pi?.email || ''
+  showClerkModal.value = true
+}
+
+function completeVerification() {
+  showClerkModal.value = false
+  isSigned.value = true
+}
+
+async function submitSigned() {
+  if (!study.value || !agreement.value) return
+  isSubmitting.value = true
+  try {
+    await $fetch('/api/admin/sign-agreement', {
+      method: 'POST',
+      body: {
+        studyId: studyId.value,
+        agreementId: agreementId.value,
+        signerName: signerName.value,
+        signerEmail: signerEmail.value,
+        token: signToken.value,
+      },
+    })
+    isSubmitted.value = true
+  }
+  catch {
+    alert('An error occurred while submitting. Please try again.')
+  }
+  finally {
+    isSubmitting.value = false
+  }
+}
+</script>
+
+<template>
+  <div style="min-height:100vh; background:var(--paper);">
+    <!-- Top bar -->
+    <div class="sign-topbar">
+      <div class="sign-brand">
+        <div class="mark">I3H</div>
+        Immune Health
+      </div>
+      <span style="color:rgba(255,255,255,0.5); font-size:0.78rem">
+        Secure document signing · {{ study?.name }}
+      </span>
+      <div class="clerk-pill">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="12" height="12">
+          <rect x="3" y="11" width="18" height="11" rx="2" />
+          <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+        </svg>
+        Secured by Clerk
+      </div>
+    </div>
+
+    <!-- Admin preview banner -->
+    <div v-if="isPreview" style="background:#b7950b;color:#fff;text-align:center;padding:0.5rem 1rem;font-size:0.82rem;font-weight:500;">
+      Admin preview — this is what the PI sees. Signing is disabled without a valid secure link.
+    </div>
+
+    <div class="sign-wrap" v-if="study && agreement">
+      <!-- Success confirmation (after submit) -->
+      <div v-if="isSubmitted" class="sign-confirm-card">
+        <div class="check-circle">✓</div>
+        <div>
+          <h4>Document submitted successfully</h4>
+          <p>Your signature has been recorded and the I3H team has been notified. You'll receive a countersigned copy by email.</p>
+        </div>
+      </div>
+
+      <div class="sign-hero">
+        <div class="crumbs">Institute for Immunology &amp; Immune Health · {{ study.name }}</div>
+        <h1>{{ (agreement as any).name }}</h1>
+        <p>Please review the terms below carefully before signing. This document is legally binding once countersigned by I3H staff.</p>
+      </div>
+
+      <div class="sign-doc">
+        <div class="sign-doc-head">
+          <h2>{{ (agreement as any).name }}</h2>
+          <div class="doc-meta">Ref: {{ study.abbreviation }}-{{ String((agreement as any).id).toUpperCase() }}-2026 · I3H/{{ study.irb }}</div>
+        </div>
+
+        <div class="sign-doc-body">
+          <p>
+            This agreement is entered into between the <strong>University of Pennsylvania, Institute for Immunology &amp; Immune Health (I3H)</strong>
+            and <strong>{{ (study as any).affiliation_org }}</strong>, represented by {{ (study.pi as any).name }}.
+          </p>
+
+          <div class="key-terms">
+            <div class="r"><span class="l">Study</span><span class="v">{{ study.name }}</span></div>
+            <div class="r"><span class="l">Principal Investigator</span><span class="v">{{ (study.pi as any).name }}</span></div>
+            <div class="r"><span class="l">IRB Protocol</span><span class="v">{{ study.irb }}</span></div>
+            <div class="r"><span class="l">Sample scope</span><span class="v">{{ (study.cohort as any).subjects }} subjects × {{ (study.cohort as any).timepoints }} timepoints = {{ (study.cohort as any).totalSamples }} samples</span></div>
+            <div class="r"><span class="l">Sample type</span><span class="v">{{ (study.cohort as any).sampleType }}</span></div>
+          </div>
+
+          <h3>1. Scope of Services</h3>
+          <p>
+            I3H agrees to provide the following services as outlined in the Rate Schedule and in accordance with
+            the study protocol approved under the above IRB number. All services will be performed using
+            standardized I3H protocols unless prior written deviation is approved.
+          </p>
+          <ol>
+            <li v-for="line in (study.budget as any).lines" :key="(line as any).service">
+              {{ (line as any).service }} — {{ (line as any).planned }} units at ${{ (line as any).rate }}/unit (est. ${{ Number((line as any).committed).toLocaleString() }})
+            </li>
+          </ol>
+
+          <h3>2. Data Ownership &amp; Access</h3>
+          <p>
+            All raw data, processed outputs, and analysis results generated by I3H are the property of the
+            PI's institution. I3H retains rights to de-identified aggregate metrics for internal quality
+            benchmarking only. Data will be delivered via the Pennsieve platform.
+          </p>
+
+          <h3>3. Confidentiality</h3>
+          <p>
+            Both parties agree to maintain strict confidentiality of all research data, protocols, and
+            results. I3H staff are bound by Penn confidentiality policies and HIPAA-compliant handling procedures.
+          </p>
+
+          <h3>4. Payment Terms</h3>
+          <p>
+            Invoices will be issued on a per-batch basis through the iLabs Solutions platform against
+            the account code specified in the Rate Schedule. Payment is due within 30 days of invoice.
+          </p>
+        </div>
+
+        <div class="sign-doc-foot">
+          <div class="sign-row">
+            <!-- PI signature block -->
+            <div class="sign-block">
+              <div class="lbl-big">Principal Investigator signature</div>
+              <div v-if="!isSigned" class="sign-empty">
+                Click "Sign with Clerk" to add your signature
+              </div>
+              <div v-else class="sig-stamp" style="display:block;">
+                <div class="sig-name">{{ signerName }}</div>
+                <div class="sig-meta">Digitally signed · verified via Clerk</div>
+                <div class="sig-verified">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M12 2 4 5v6c0 5 3.5 9.5 8 11 4.5-1.5 8-6 8-11V5l-8-3z" />
+                    <polyline points="9 12 11 14 15 10" />
+                  </svg>
+                  Verified: {{ signerName }} ({{ signerEmail }})
+                </div>
+              </div>
+            </div>
+
+            <!-- I3H countersignature -->
+            <div class="sign-block">
+              <div class="lbl-big">I3H countersignature</div>
+              <div class="sign-counter-box">
+                <div class="name">Lori Guercio</div>
+                <div class="role">Operations Lead · Institute for Immunology &amp; Immune Health</div>
+                <div class="note">I3H will countersign within 2 business days of PI submission.</div>
+              </div>
+            </div>
+          </div>
+
+          <div class="sign-cta-bar">
+            <p class="legal">
+              By signing, you confirm that you have read and agreed to the terms above and that you are
+              authorized to enter into this agreement on behalf of your institution.
+            </p>
+            <div class="cta-btns">
+              <button class="btn-back" @click="$router.back()">← Back</button>
+              <button
+                v-if="!isSigned"
+                class="btn-sign"
+                :disabled="isPreview"
+                @click="openClerk"
+              >
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16">
+                  <path d="M12 2 4 5v6c0 5 3.5 9.5 8 11 4.5-1.5 8-6 8-11V5l-8-3z" />
+                </svg>
+                Sign with Clerk
+              </button>
+              <button
+                v-else
+                class="btn-sign btn-submit"
+                :disabled="isSubmitted || isSubmitting"
+                @click="submitSigned"
+              >
+                {{ isSubmitted ? '✓ Submitted' : isSubmitting ? 'Submitting…' : '✓ Submit signed document' }}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Clerk verification modal -->
+    <div v-if="showClerkModal" class="clerk-overlay" @click.self="showClerkModal = false">
+      <div class="clerk-modal">
+        <div class="cm-head">
+          <div class="clerk-brand">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="12" height="12">
+              <rect x="3" y="11" width="18" height="11" rx="2" />
+              <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+            </svg>
+            Secured by Clerk
+          </div>
+          <h3>Verify your identity</h3>
+          <p class="cm-lead">Confirm your details to sign this document.</p>
+        </div>
+        <div class="cm-body">
+          <div class="cm-field">
+            <label class="lbl">Full legal name</label>
+            <input v-model="signerName" type="text" placeholder="As it appears on the document">
+          </div>
+          <div class="cm-field">
+            <label class="lbl">Institutional email</label>
+            <input v-model="signerEmail" type="email" placeholder="name@institution.edu">
+          </div>
+          <div class="cm-or">or verify with</div>
+          <div class="cm-oauth">
+            <button>🏛️ Penn SSO</button>
+            <button>🔬 ORCID</button>
+          </div>
+          <button class="btn-verify" @click="completeVerification">
+            Confirm identity &amp; sign
+          </button>
+          <div class="cm-legal">
+            By proceeding, you confirm this signature is legally binding.
+            Your identity has been verified via Clerk.
+          </div>
+        </div>
+        <div class="cm-foot">
+          <strong>Clerk Authentication</strong> · Institute for Immunology &amp; Immune Health
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/pages/admin/studies/[id].vue
+++ b/pages/admin/studies/[id].vue
@@ -1,0 +1,489 @@
+<script setup lang="ts">
+import { useAdminStore } from '~/stores/admin'
+
+definePageMeta({ layout: 'admin' })
+
+const route = useRoute()
+const adminStore = useAdminStore()
+
+const study = computed(() => adminStore.studies.find(s => s.id === route.params.id))
+
+if (!study.value) {
+  navigateTo('/admin/studies')
+}
+
+const activeTab = ref('overview')
+
+const signedCount = computed(() =>
+  study.value ? study.value.agreements.filter(a => a.status === 'Signed').length : 0
+)
+
+function openAgreementsTab() {
+  activeTab.value = 'agreements'
+}
+
+const sendingLink = ref<string | null>(null)
+const sentLink = ref<Set<string>>(new Set())
+
+async function sendSignLink(studyId: string, agreementId: string) {
+  const key = `${studyId}-${agreementId}`
+  sendingLink.value = key
+  try {
+    await $fetch('/api/admin/send-sign-link', {
+      method: 'POST',
+      body: { studyId, agreementId },
+    })
+    sentLink.value = new Set([...sentLink.value, key])
+  }
+  catch {
+    alert('Failed to send signing link. Please try again.')
+  }
+  finally {
+    sendingLink.value = null
+  }
+}
+
+const stageClass = computed(() => {
+  if (!study.value) return ''
+  if (study.value.stage === 'Complete') return 'b-complete'
+  if (study.value.stage === 'Processing') return 'b-processing'
+  if (study.value.stage === 'Awaiting Signature' || study.value.stage === 'Agreement') return 'b-agreement'
+  return 'b-review'
+})
+
+const affiliationClass = computed(() => {
+  if (!study.value) return ''
+  if (study.value.affiliation === 'Internal') return 'b-internal'
+  if (study.value.affiliation === 'External') return 'b-external'
+  return 'b-industry'
+})
+</script>
+
+<template>
+  <div v-if="study">
+    <div class="crumbs">
+      <NuxtLink to="/admin/studies" class="crumb-link">Studies</NuxtLink>
+      <span class="sep">›</span>
+      <span>{{ study.name }}</span>
+    </div>
+
+    <!-- Hero -->
+    <div class="detail-hero">
+      <div>
+        <h2>
+          {{ study.name }}
+          <span class="acronym">{{ study.abbreviation }}</span>
+          <span class="adm-badge" :class="affiliationClass">
+            <span class="dot" /> Penn {{ study.affiliation }}
+          </span>
+          <span class="adm-badge" :class="stageClass">
+            <span class="dot" /> {{ study.stage }}
+          </span>
+        </h2>
+        <div class="pi-line">
+          <strong>{{ study.pi.name }}</strong> · {{ study.affiliationOrg }} ·
+          <span class="mono">{{ study.pi.email }}</span>
+        </div>
+        <div class="meta-strip">
+          <div v-if="study.studyLead" class="meta-item">
+            <span class="meta-label">Study lead</span>
+            <span class="meta-val">{{ study.studyLead.name }}</span>
+          </div>
+          <div class="meta-item">
+            <span class="meta-label">IRB</span>
+            <span class="meta-val">{{ study.irb }}</span>
+          </div>
+          <div v-if="study.startedDate" class="meta-item">
+            <span class="meta-label">Started</span>
+            <span class="meta-val">{{ study.startedDate }}</span>
+          </div>
+          <div class="meta-item">
+            <span class="meta-label">Cohort</span>
+            <span class="meta-val">{{ study.cohort.subjects }} × {{ study.cohort.timepoints }} = {{ study.cohort.totalSamples }} samples</span>
+          </div>
+          <div class="meta-item">
+            <span class="meta-label">Sample type</span>
+            <span class="meta-val">{{ study.cohort.sampleType }}</span>
+          </div>
+        </div>
+      </div>
+      <div class="hero-actions">
+        <template v-if="study.isLocked">
+          <div class="status-strip">
+            <span class="dot" />
+            <span class="txt">Agreements pending · {{ study.agreements.filter(a => a.status === 'Pending').length }} outstanding</span>
+          </div>
+          <button class="btn btn-secondary btn-sm">Resend agreement reminder</button>
+        </template>
+        <button class="btn btn-ghost btn-sm">Edit study record</button>
+      </div>
+    </div>
+
+    <!-- Locked banner -->
+    <div v-if="study.isLocked" class="locked-banner">
+      <div class="lock-icon">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="3" y="11" width="18" height="11" rx="2" />
+          <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+        </svg>
+      </div>
+      <div class="lock-body">
+        <h4>Sample processing locked until all agreements are signed</h4>
+        <p>
+          <span class="frac">{{ signedCount }} of {{ study.agreements.length }}</span>
+          agreements countersigned. The
+          {{ study.agreements.find(a => a.status === 'Pending')?.name }}
+          is still awaiting Dr. {{ study.pi.name.replace('Dr. ', '') }}'s signature.
+          Study activation, sample drop-off, and processing are blocked until then.
+        </p>
+      </div>
+      <div class="lock-actions">
+        <button class="btn btn-secondary btn-sm">Resend reminder</button>
+        <button class="btn btn-primary btn-sm" @click="openAgreementsTab">Open agreements →</button>
+      </div>
+    </div>
+
+    <!-- Lifecycle -->
+    <div class="lifecycle-section">
+      <h3>Lifecycle</h3>
+      <div class="sub">From intake to data delivery — every step time-stamped by the platform.</div>
+      <div class="life-timeline">
+        <div
+          v-for="step in study.lifecycle"
+          :key="step.label"
+          class="life-step"
+          :class="step.status"
+        >
+          <div class="life-dot" />
+          <div class="life-label">{{ step.label }}</div>
+          <div class="life-when">{{ step.date }}</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Tabs -->
+    <div class="tabs">
+      <button class="tab-btn" :class="{ active: activeTab === 'overview' }" @click="activeTab = 'overview'">Overview</button>
+      <button class="tab-btn" :class="{ active: activeTab === 'agreements' }" @click="activeTab = 'agreements'">
+        Agreements
+        <span class="tab-count">{{ signedCount }}/{{ study.agreements.length }}</span>
+      </button>
+      <button class="tab-btn" :class="{ active: activeTab === 'cohort' }" @click="activeTab = 'cohort'">
+        Cohort &amp; samples
+        <span v-if="study.isLocked" class="tab-count" style="background:rgba(183,149,11,0.12); color:var(--gold)">Locked</span>
+      </button>
+      <button class="tab-btn" :class="{ active: activeTab === 'budget' }" @click="activeTab = 'budget'">Budget</button>
+      <button class="tab-btn" :class="{ active: activeTab === 'notes' }" @click="activeTab = 'notes'">Notes &amp; activity</button>
+    </div>
+
+    <!-- OVERVIEW -->
+    <div v-if="activeTab === 'overview'" class="dt-grid">
+      <div class="panel">
+        <div class="panel-head"><h3>Study summary</h3></div>
+        <div class="study-info-grid">
+          <div class="info-lbl">Objectives</div>
+          <div>{{ study.objectives }}</div>
+
+          <div class="info-lbl">PI / Lead</div>
+          <div>
+            {{ study.pi.name }} (PI)
+            <template v-if="study.studyLead"> · {{ study.studyLead.name }} (lead) · <span class="mono">{{ study.studyLead.email }}</span></template>
+          </div>
+
+          <div v-if="study.department" class="info-lbl">Department</div>
+          <div v-if="study.department">{{ study.department }}</div>
+
+          <div v-if="study.phlebotomy" class="info-lbl">Phlebotomy</div>
+          <div v-if="study.phlebotomy">{{ study.phlebotomy }}</div>
+
+          <div v-if="study.metadata" class="info-lbl">Metadata</div>
+          <div v-if="study.metadata">{{ study.metadata }}</div>
+
+          <div class="info-lbl">Services</div>
+          <div>
+            <div v-for="line in study.budget.lines" :key="line.service">
+              {{ line.service }} · <span class="mono">${{ line.rate }} × {{ line.planned }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <div class="panel" style="margin-bottom:1.2rem;">
+          <div class="panel-head"><h3>Integrations</h3></div>
+          <div class="integ-grid">
+            <div v-if="study.integrations.redcap" class="integ-card linked">
+              <div class="integ-head">REDCap <span style="color:var(--green)">●</span></div>
+              <div class="integ-val">{{ study.integrations.redcap }}</div>
+              <button class="integ-act">Open project →</button>
+            </div>
+            <div v-if="study.integrations.labvantage" class="integ-card linked">
+              <div class="integ-head">LabVantage <span style="color:var(--green)">●</span></div>
+              <div class="integ-val">{{ study.integrations.labvantage }}</div>
+              <button class="integ-act">View samples →</button>
+            </div>
+            <div v-if="study.integrations.pennsieve" class="integ-card linked">
+              <div class="integ-head">Pennsieve <span style="color:var(--green)">●</span></div>
+              <div class="integ-val" style="font-size:0.72rem">{{ study.integrations.pennsieve }}</div>
+              <button class="integ-act">Open dataset →</button>
+            </div>
+            <div v-if="!study.integrations.labvantage" class="integ-card pending">
+              <div class="integ-head">LabVantage <span style="color:var(--gold)">●</span></div>
+              <div class="integ-val" style="color:var(--muted)">Not yet assigned</div>
+            </div>
+            <div v-if="!study.integrations.pennsieve" class="integ-card pending">
+              <div class="integ-head">Pennsieve <span style="color:var(--gold)">●</span></div>
+              <div class="integ-val" style="color:var(--muted)">Not yet provisioned</div>
+            </div>
+          </div>
+        </div>
+
+        <div v-if="study.quickStats" class="panel">
+          <div class="panel-head"><h3>Quick stats</h3></div>
+          <div class="quick-stats">
+            <div class="qs-card">
+              <div class="qs-lbl">Samples received</div>
+              <div class="qs-val" style="color:var(--green)">{{ study.quickStats.samplesReceived }} / {{ study.quickStats.samplesTotal }}</div>
+            </div>
+            <div class="qs-card">
+              <div class="qs-lbl">CyTOF acquired</div>
+              <div class="qs-val" style="color:var(--gold)">{{ study.quickStats.cytofAcquired }} / {{ study.quickStats.cytofTotal }}</div>
+            </div>
+            <div class="qs-card">
+              <div class="qs-lbl">QC passed</div>
+              <div class="qs-val" style="color:var(--accent)">{{ study.quickStats.qcPassed }} / {{ study.quickStats.qcTotal }}</div>
+            </div>
+            <div class="qs-card">
+              <div class="qs-lbl">Invoiced YTD</div>
+              <div class="qs-val" style="color:var(--warm)">${{ study.quickStats.invoicedYtd.toLocaleString() }}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- AGREEMENTS -->
+    <div v-if="activeTab === 'agreements'">
+      <div class="panel">
+        <div class="panel-head">
+          <h3>Agreement package</h3>
+          <span class="ctx">{{ signedCount }} of {{ study.agreements.length }} signed · secured link via email</span>
+        </div>
+
+        <div v-for="agreement in study.agreements" :key="agreement.id" class="agree-item" :class="{ 'pending-bg': agreement.status === 'Pending' }">
+          <div class="agree-check" :class="agreement.status === 'Signed' ? 'signed' : 'pending'">
+            {{ agreement.status === 'Signed' ? '✓' : '!' }}
+          </div>
+          <div>
+            <div class="agree-name">{{ agreement.name }}</div>
+            <div class="agree-desc">{{ agreement.description }}</div>
+          </div>
+
+          <template v-if="agreement.status === 'Signed'">
+            <div class="sig-stamp">
+              <div class="sig-name">{{ agreement.signedBy }}</div>
+              <div class="sig-meta">Digitally signed {{ agreement.signedDate }}</div>
+              <div class="sig-verified">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M12 2 4 5v6c0 5 3.5 9.5 8 11 4.5-1.5 8-6 8-11V5l-8-3z" />
+                  <polyline points="9 12 11 14 15 10" />
+                </svg>
+                Verified: {{ agreement.signedBy }} ({{ agreement.signedEmail }})
+              </div>
+            </div>
+            <button class="btn btn-ghost btn-sm" @click="alert('Opens signed PDF in Pennsieve')">View document</button>
+          </template>
+
+          <template v-else>
+            <div class="sig-pending">
+              <span class="sig-pend-ttl">⌛ Awaiting PI signature</span>
+              <span class="sig-pend-sub">Secure sign link sent {{ agreement.sentDate }}<template v-if="agreement.reminderDate"> · reminder {{ agreement.reminderDate }}</template></span>
+            </div>
+            <div style="display:flex; flex-direction:column; gap:0.4rem; align-items:flex-end;">
+              <NuxtLink :to="'/admin/sign/' + study.id + '-' + agreement.id" class="btn btn-primary btn-sm">
+                Preview PI sign view →
+              </NuxtLink>
+              <button
+                class="btn btn-ghost btn-sm"
+                :disabled="sendingLink === study.id + '-' + agreement.id"
+                @click="sendSignLink(study.id, agreement.id)"
+              >
+                {{ sentLink.has(study.id + '-' + agreement.id) ? '✓ Link sent' : sendingLink === study.id + '-' + agreement.id ? 'Sending…' : 'Resend secure link' }}
+              </button>
+            </div>
+          </template>
+        </div>
+
+        <div class="panel-foot">
+          <span class="ctx">Signatures captured via secure email link · stored to Pennsieve</span>
+          <div style="display:flex; gap:0.5rem">
+            <button class="btn btn-secondary btn-sm">Download package</button>
+            <button class="btn btn-ghost btn-sm">Mark signed manually</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Document history -->
+      <div class="panel" style="margin-top:1.2rem;">
+        <div class="panel-head"><h3>Document history</h3></div>
+        <div class="activity-timeline">
+          <div v-for="(item, i) in study.activity.slice(0, 5)" :key="i" class="t-item">
+            <div class="t-dot" :class="item.dotClass" />
+            <div class="t-body">
+              <div class="t-title">{{ item.title }}</div>
+              <div class="t-meta">{{ item.date }}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- COHORT -->
+    <div v-if="activeTab === 'cohort'">
+      <div v-if="study.isLocked" class="locked-empty">
+        <div class="ico-big">
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="3" y="11" width="18" height="11" rx="2" />
+            <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+          </svg>
+        </div>
+        <h3>Cohort &amp; sample tracking unlocks at activation</h3>
+        <p>
+          Sample drop-off, processing events, QC, and the per-sample table all become available
+          once the full agreement package is countersigned and a LabVantage study ID is assigned.
+          <strong style="color:var(--ink)">{{ signedCount }} of {{ study.agreements.length }} agreements</strong> are complete.
+        </p>
+        <div style="display:flex; gap:0.6rem; justify-content:center;">
+          <button class="btn btn-secondary btn-sm" @click="activeTab = 'agreements'">Open agreements</button>
+          <NuxtLink :to="'/admin/sign/' + study.id + '-psa'" class="btn btn-primary btn-sm">
+            Preview PI sign view →
+          </NuxtLink>
+        </div>
+
+        <div style="margin-top:1.8rem; padding-top:1.4rem; border-top:1px solid rgba(0,0,0,0.06); max-width:520px; margin-left:auto; margin-right:auto;">
+          <div style="font-size:0.66rem; text-transform:uppercase; letter-spacing:0.1em; color:var(--muted); font-weight:600; margin-bottom:0.6rem">Planned scope at activation</div>
+          <div style="display:grid; grid-template-columns:1fr 1fr; gap:0.8rem; text-align:left;">
+            <div style="padding:0.7rem 0.9rem; background:var(--cream); border-radius:var(--radius);">
+              <div style="font-size:0.62rem; text-transform:uppercase; letter-spacing:0.1em; color:var(--muted); font-weight:600">Subjects</div>
+              <div class="mono" style="font-size:1.1rem; font-weight:500">{{ study.cohort.subjects }}</div>
+            </div>
+            <div style="padding:0.7rem 0.9rem; background:var(--cream); border-radius:var(--radius);">
+              <div style="font-size:0.62rem; text-transform:uppercase; letter-spacing:0.1em; color:var(--muted); font-weight:600">Timepoints / subject</div>
+              <div class="mono" style="font-size:1.1rem; font-weight:500">{{ study.cohort.timepoints }}</div>
+            </div>
+            <div style="padding:0.7rem 0.9rem; background:var(--cream); border-radius:var(--radius);">
+              <div style="font-size:0.62rem; text-transform:uppercase; letter-spacing:0.1em; color:var(--muted); font-weight:600">Total samples</div>
+              <div class="mono" style="font-size:1.1rem; font-weight:500">{{ study.cohort.totalSamples }}</div>
+            </div>
+            <div style="padding:0.7rem 0.9rem; background:var(--cream); border-radius:var(--radius);">
+              <div style="font-size:0.62rem; text-transform:uppercase; letter-spacing:0.1em; color:var(--muted); font-weight:600">Sample type</div>
+              <div style="font-size:0.88rem; font-weight:500">{{ study.cohort.sampleType }}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div v-else class="panel">
+        <div class="panel-head">
+          <h3>Cohort progress</h3>
+          <span class="ctx">{{ study.cohort.processedSamples }} / {{ study.cohort.totalSamples }} samples processed</span>
+        </div>
+        <div style="padding:1.4rem; text-align:center; color:var(--muted); font-size:0.88rem; font-weight:300">
+          Full per-sample table and processing events will appear here once samples begin arriving.<br>
+          <strong style="color:var(--ink)">Phase 1 placeholder</strong> — build out with LabVantage integration.
+        </div>
+      </div>
+    </div>
+
+    <!-- BUDGET -->
+    <div v-if="activeTab === 'budget'">
+      <div class="panel">
+        <div class="panel-head">
+          <h3>Budget vs. actuals</h3>
+          <span v-if="study.budget.accountCode" class="ctx">Account: {{ study.budget.accountCode }} · billed via iLabs</span>
+        </div>
+        <div class="budget-grid">
+          <div class="budget-card">
+            <div class="lbl">Committed</div>
+            <div class="val">${{ study.budget.committed.toLocaleString() }}</div>
+          </div>
+          <div class="budget-card">
+            <div class="lbl">Invoiced</div>
+            <div class="val" style="color:var(--warm)">${{ study.budget.invoiced.toLocaleString() }}</div>
+          </div>
+          <div class="budget-card">
+            <div class="lbl">Remaining</div>
+            <div class="val" style="color:var(--green)">${{ study.budget.remaining.toLocaleString() }}</div>
+          </div>
+        </div>
+        <div class="budget-prog"><div :style="{ width: study.budget.pctInvoiced + '%' }" /></div>
+        <div style="padding:0.6rem 1.4rem 0; font-size:0.78rem; color:var(--muted)">
+          {{ study.budget.pctInvoiced }}% of committed budget invoiced
+        </div>
+
+        <table class="budget-table">
+          <thead>
+            <tr>
+              <th>Service</th>
+              <th>Rate</th>
+              <th>Planned</th>
+              <th>Completed</th>
+              <th>Committed</th>
+              <th>Invoiced</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="line in study.budget.lines" :key="line.service">
+              <td>{{ line.service }}</td>
+              <td class="mono">${{ line.rate }}</td>
+              <td class="mono">{{ line.planned }}</td>
+              <td class="mono">{{ line.completed }}</td>
+              <td class="mono">${{ line.committed.toLocaleString() }}</td>
+              <td class="mono">${{ line.invoiced.toLocaleString() }}</td>
+            </tr>
+            <tr style="background:rgba(0,0,0,0.02)">
+              <td colspan="4" style="text-align:right; font-weight:600">Totals</td>
+              <td class="mono" style="font-weight:600; color:var(--accent)">${{ study.budget.committed.toLocaleString() }}</td>
+              <td class="mono" style="font-weight:600; color:var(--warm)">${{ study.budget.invoiced.toLocaleString() }}</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="panel-foot">
+          <span class="ctx">Billing contact: {{ study.budget.billingContact }}</span>
+          <div style="display:flex; gap:0.5rem">
+            <button class="btn btn-secondary btn-sm">Export invoice CSV</button>
+            <button class="btn btn-primary btn-sm">Mark invoice sent</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- NOTES & ACTIVITY -->
+    <div v-if="activeTab === 'notes'">
+      <div class="panel">
+        <div class="panel-head">
+          <h3>Notes &amp; activity</h3>
+          <span class="ctx">Combined audit log · internal staff only</span>
+        </div>
+        <div class="activity-timeline">
+          <div v-for="(item, i) in study.activity" :key="i" class="t-item">
+            <div class="t-dot" :class="item.dotClass" />
+            <div class="t-body">
+              <div class="t-title">{{ item.title }}</div>
+              <div class="t-meta">{{ item.date }}</div>
+              <div v-if="item.note" class="t-note">{{ item.note }}</div>
+            </div>
+          </div>
+        </div>
+        <div class="note-composer">
+          <textarea placeholder="Add an internal note (visible only to I3H staff)…" />
+          <div class="composer-actions">
+            <button class="btn btn-secondary btn-sm">Cancel</button>
+            <button class="btn btn-primary btn-sm">Post note</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/pages/admin/studies/index.vue
+++ b/pages/admin/studies/index.vue
@@ -1,0 +1,182 @@
+<script setup lang="ts">
+import { useAdminStore } from '~/stores/admin'
+import type { StudyStage, Affiliation } from '~/stores/admin'
+
+definePageMeta({ layout: 'admin' })
+
+const adminStore = useAdminStore()
+const stageFilter = ref<StudyStage | 'All'>('All')
+const affiliationFilter = ref<Affiliation | 'All affiliations'>('All affiliations')
+const searchQuery = ref('')
+
+const stageFilters: Array<{ label: string; value: StudyStage | 'All'; count: number }> = [
+  { label: 'All', value: 'All', count: adminStore.studies.length },
+  { label: 'Agreement', value: 'Agreement', count: adminStore.studies.filter(s => s.stage === 'Agreement' || s.stage === 'Awaiting Signature').length },
+  { label: 'Processing', value: 'Processing', count: adminStore.studies.filter(s => s.stage === 'Processing').length },
+  { label: 'Complete', value: 'Complete', count: adminStore.studies.filter(s => s.stage === 'Complete').length },
+]
+
+const affiliationFilters = ['All affiliations', 'Internal', 'External', 'Industry']
+
+const stageClass = (stage: StudyStage) => {
+  if (stage === 'Complete') return 'b-complete'
+  if (stage === 'Processing') return 'b-processing'
+  if (stage === 'Agreement' || stage === 'Awaiting Signature') return 'b-agreement'
+  return 'b-review'
+}
+
+const affiliationClass = (aff: Affiliation) => {
+  if (aff === 'Internal') return 'b-internal'
+  if (aff === 'External') return 'b-external'
+  return 'b-industry'
+}
+
+const displayedStudies = computed(() => {
+  let list = adminStore.studies
+  if (stageFilter.value !== 'All') {
+    list = list.filter(s =>
+      stageFilter.value === 'Agreement'
+        ? (s.stage === 'Agreement' || s.stage === 'Awaiting Signature')
+        : s.stage === stageFilter.value
+    )
+  }
+  if (affiliationFilter.value !== 'All affiliations') {
+    list = list.filter(s => s.affiliation === affiliationFilter.value)
+  }
+  if (searchQuery.value) {
+    const q = searchQuery.value.toLowerCase()
+    list = list.filter(s =>
+      s.name.toLowerCase().includes(q) ||
+      s.pi.name.toLowerCase().includes(q) ||
+      s.irb.toLowerCase().includes(q)
+    )
+  }
+  return list
+})
+
+const signedCount = (study: typeof adminStore.studies[0]) =>
+  study.agreements.filter(a => a.status === 'Signed').length
+</script>
+
+<template>
+  <div>
+    <div class="page-hd">
+      <div>
+        <h1>Studies</h1>
+        <div class="sub">All active and historical studies. Click a row to open its lifecycle.</div>
+      </div>
+      <div class="hd-actions">
+        <button class="btn btn-secondary btn-sm">Export CSV</button>
+        <button class="btn btn-primary btn-sm">+ New study</button>
+      </div>
+    </div>
+
+    <div class="toolbar">
+      <div class="chip-group">
+        <button
+          v-for="f in stageFilters"
+          :key="f.value"
+          class="chip"
+          :class="{ active: stageFilter === f.value }"
+          @click="stageFilter = f.value"
+        >
+          {{ f.label }} <span class="chip-count">{{ f.count }}</span>
+        </button>
+      </div>
+      <div class="chip-group">
+        <button
+          v-for="aff in affiliationFilters"
+          :key="aff"
+          class="chip"
+          :class="{ active: affiliationFilter === aff }"
+          @click="affiliationFilter = aff as Affiliation | 'All affiliations'"
+        >
+          {{ aff }}
+        </button>
+      </div>
+      <div class="toolbar-search">
+        <input v-model="searchQuery" type="search" placeholder="Search study, PI, IRB…">
+      </div>
+      <div class="toolbar-spacer" />
+      <button class="btn btn-ghost btn-sm">Sort: Updated ↓</button>
+    </div>
+
+    <div class="table-wrap">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>Study</th>
+            <th>PI</th>
+            <th>Affil.</th>
+            <th>IRB</th>
+            <th>Stage</th>
+            <th>Agreements</th>
+            <th>Cohort progress</th>
+            <th>Budget</th>
+            <th>Updated</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="study in displayedStudies"
+            :key="study.id"
+            @click="navigateTo('/admin/studies/' + study.id)"
+          >
+            <td>
+              <div class="study-name">{{ study.name }}</div>
+              <div class="study-pi">{{ study.abbreviation }} · IRB {{ study.irb }}</div>
+            </td>
+            <td>
+              <div>{{ study.pi.name }}</div>
+              <div class="study-pi mono" style="font-size:0.7rem">{{ study.pi.email.split('@')[0] }}@…</div>
+            </td>
+            <td>
+              <span class="adm-badge" :class="affiliationClass(study.affiliation)">{{ study.affiliation }}</span>
+            </td>
+            <td class="mono" style="font-size:0.78rem">{{ study.irb }}</td>
+            <td>
+              <span class="adm-badge" :class="stageClass(study.stage)">
+                <span class="dot" /> {{ study.stage }}
+              </span>
+            </td>
+            <td>
+              <div class="cell-progress">
+                <div class="prog-bar" :class="signedCount(study) < study.agreements.length ? 'gold' : ''">
+                  <div :style="{ width: (signedCount(study) / study.agreements.length * 100) + '%' }" />
+                </div>
+                <div class="prog-frac" :style="study.isLocked ? 'color:var(--warm)' : ''">
+                  {{ study.isLocked ? 'locked' : signedCount(study) + '/' + study.agreements.length }}
+                </div>
+              </div>
+            </td>
+            <td>
+              <div class="cell-progress">
+                <div class="prog-bar" :class="study.cohort.processedSamples === 0 ? 'accent' : ''">
+                  <div :style="{ width: (study.cohort.processedSamples / study.cohort.totalSamples * 100) + '%' }" />
+                </div>
+                <div class="prog-frac">{{ study.cohort.processedSamples }}/{{ study.cohort.totalSamples }}</div>
+              </div>
+            </td>
+            <td>
+              <div class="mono" style="font-size:0.82rem">
+                {{ study.budget.invoiced > 0 ? '$' + (study.budget.invoiced / 1000).toFixed(1) + 'K' : '—' }}
+              </div>
+              <div class="study-pi" style="font-size:0.7rem">
+                {{ study.stage === 'Complete' ? 'final' : 'est. $' + (study.budget.committed / 1000).toFixed(0) + 'K' }}
+              </div>
+            </td>
+            <td class="mono" style="font-size:0.78rem; color:var(--muted)">{{ study.updatedRelative }}</td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="pagination">
+        <span>Showing {{ displayedStudies.length }} of {{ adminStore.studies.length }} studies</span>
+        <div class="pag-controls">
+          <button>‹</button>
+          <button class="active">1</button>
+          <button>›</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/pages/intake.vue
+++ b/pages/intake.vue
@@ -111,6 +111,16 @@ const submitForm = async () => {
       return `${service?.name || req.serviceId} (qty: ${req.quantity})`
     }).join(', ')
 
+    const servicesDetail = form.services.map((req) => {
+      const service = servicesStore.services.find(s => s.id === req.serviceId)
+      const rate = servicesStore.getServiceRate(req.serviceId)
+      return {
+        name: service?.name || req.serviceId,
+        qty: req.quantity,
+        rate: rate === 0 ? 'Contact' : `$${rate}/ea`,
+      }
+    })
+
     await $fetch('/api/submit-intake', {
       method: 'POST',
       body: {
@@ -118,6 +128,7 @@ const submitForm = async () => {
         estimatedTotal: estimatedTotal.value,
         totalSamples: totalSamples.value,
         servicesText,
+        servicesDetail,
       },
     })
 

--- a/server/api/admin/approve-inquiry.post.ts
+++ b/server/api/admin/approve-inquiry.post.ts
@@ -1,0 +1,197 @@
+import { serverSupabaseServiceRole } from '#supabase/server'
+import { createSignToken } from '~/server/utils/signing'
+
+const AGREEMENTS = [
+  { id: 'ua',  name: 'User Agreement',                description: 'Master scope of work between PI and I3H' },
+  { id: 'rs',  name: 'Rate Schedule',                 description: 'Itemized pricing and billing terms' },
+  { id: 'lv',  name: 'LabVantage Sample Intake Form', description: 'Sample ID assignment authorization' },
+  { id: 'psa', name: 'Pennsieve Data Sharing Agreement', description: 'Data hosting + access controls on Pennsieve workspace' },
+]
+
+function parseRate(rateStr: string): number {
+  const match = rateStr.match(/\$?([\d,]+)/)
+  return match ? parseInt(match[1].replace(/,/g, '')) : 0
+}
+
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
+  const { inquiryId } = await readBody(event)
+
+  if (!inquiryId) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing inquiryId' })
+  }
+
+  const supabase = serverSupabaseServiceRole(event)
+
+  const { data: inquiry, error: fetchErr } = await supabase
+    .from('inquiries')
+    .select('*')
+    .eq('id', inquiryId)
+    .single()
+
+  if (fetchErr || !inquiry) {
+    throw createError({ statusCode: 404, statusMessage: 'Inquiry not found' })
+  }
+  if (inquiry.status === 'Approved' || inquiry.status === 'Declined') {
+    throw createError({ statusCode: 409, statusMessage: 'Inquiry already processed' })
+  }
+
+  const approvedDate = new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+
+  // Generate a unique study ID from the abbreviation
+  const abbr = ((inquiry.abbreviation as string) || (inquiry.study_name as string))
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  const studyId = `${abbr}-${Math.random().toString(36).slice(2, 6)}`
+
+  // Build budget lines from services_detail
+  const servicesDetail = (inquiry.services_detail as Array<{ name: string; qty: number; rate: string }>) || []
+  const lines = servicesDetail.map(svc => {
+    const rate = parseRate(svc.rate)
+    return {
+      service: svc.name,
+      rate,
+      planned: svc.qty,
+      completed: 0,
+      committed: rate * svc.qty,
+      invoiced: 0,
+    }
+  })
+  const committed = lines.reduce((sum, l) => sum + l.committed, 0)
+
+  // 1. Create study
+  const { error: studyErr } = await supabase.from('studies').insert({
+    id: studyId,
+    name: inquiry.study_name,
+    abbreviation: inquiry.abbreviation,
+    pi: inquiry.pi,
+    study_lead: inquiry.study_lead,
+    affiliation: inquiry.affiliation,
+    affiliation_org: inquiry.affiliation_org,
+    irb: inquiry.irb,
+    stage: 'Awaiting Signature',
+    is_locked: true,
+    cohort: {
+      subjects: inquiry.cohort_subjects,
+      timepoints: inquiry.cohort_timepoints,
+      totalSamples: (inquiry.cohort_subjects as number) * (inquiry.cohort_timepoints as number),
+      processedSamples: 0,
+      sampleType: inquiry.sample_type || 'TBD',
+    },
+    budget: {
+      committed,
+      invoiced: 0,
+      remaining: committed,
+      pctInvoiced: 0,
+      lines,
+    },
+    integrations: {},
+    objectives: inquiry.objectives,
+    phlebotomy: inquiry.phlebotomy,
+    metadata_desc: inquiry.metadata,
+    lifecycle: [
+      { label: 'Inquiry',    date: inquiry.submitted_date, status: 'done' },
+      { label: 'Review',     date: approvedDate,           status: 'done' },
+      { label: 'Approved',   date: approvedDate,           status: 'done' },
+      { label: 'Agreements', date: 'in progress',          status: 'active' },
+      { label: 'Activated',  date: '—',                    status: 'pending' },
+      { label: 'Processing', date: '—',                    status: 'pending' },
+      { label: 'Delivered',  date: '—',                    status: 'pending' },
+    ],
+    updated_relative: 'just now',
+    activity: [
+      { dotClass: '', title: 'Agreement package sent to PI', date: `${approvedDate} · MailerSend` },
+      { dotClass: '', title: 'Intake approved',              date: approvedDate },
+      { dotClass: '', title: 'Intake submitted',             date: `${inquiry.submitted_date as string} · via public intake form` },
+    ],
+  })
+
+  if (studyErr) {
+    throw createError({ statusCode: 500, statusMessage: 'Failed to create study record' })
+  }
+
+  // 2. Create all 4 agreements
+  const { error: agrErr } = await supabase.from('agreements').insert(
+    AGREEMENTS.map(a => ({
+      id: a.id,
+      study_id: studyId,
+      name: a.name,
+      description: a.description,
+      status: 'Pending',
+      sent_date: approvedDate,
+    })),
+  )
+
+  if (agrErr) {
+    throw createError({ statusCode: 500, statusMessage: 'Failed to create agreement records' })
+  }
+
+  // 3. Generate signing links for all 4 agreements
+  const pi = inquiry.pi as { name: string; email: string }
+  const { origin } = getRequestURL(event)
+
+  const links = AGREEMENTS.map(a => ({
+    ...a,
+    url: `${origin}/admin/sign/${studyId}-${a.id}?token=${createSignToken(studyId, a.id, pi.email, config.signingSecret)}`,
+  }))
+
+  // 4. Email the PI
+  await $fetch('https://api.mailersend.com/v1/email', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${config.mailersendApiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: {
+      from: { email: config.mailersendFromEmail, name: config.mailersendFromName },
+      to: [{ email: pi.email, name: pi.name }],
+      subject: `Action required: Agreement package for ${inquiry.study_name as string}`,
+      html: buildApprovalEmail(pi.name, inquiry.study_name as string, inquiry.abbreviation as string, links),
+    },
+  })
+
+  // 5. Update inquiry status
+  await supabase.from('inquiries').update({ status: 'Approved' }).eq('id', inquiryId)
+
+  return { success: true, studyId }
+})
+
+function buildApprovalEmail(
+  piName: string,
+  studyName: string,
+  abbr: string,
+  links: Array<{ id: string; name: string; description: string; url: string }>,
+): string {
+  const linkRows = links.map(l => `
+    <tr>
+      <td style="padding:12px 0;border-bottom:1px solid #eee;">
+        <div style="font-weight:600;color:#011F5B;margin-bottom:2px;">${l.name}</div>
+        <div style="font-size:0.82rem;color:#888;margin-bottom:8px;">${l.description}</div>
+        <a href="${l.url}" style="background:#011F5B;color:#fff;padding:8px 18px;border-radius:4px;text-decoration:none;font-size:0.85rem;font-weight:600;">
+          Review &amp; Sign →
+        </a>
+      </td>
+    </tr>`).join('')
+
+  return `
+<div style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;max-width:600px;margin:0 auto;color:#333;line-height:1.6;">
+  <div style="background:#011F5B;padding:20px;text-align:center;">
+    <h1 style="color:#fff;margin:0;font-size:22px;">Agreement Package · I3H</h1>
+  </div>
+  <div style="padding:30px;border:1px solid #e0e0e0;border-top:none;">
+    <p>Dear ${piName},</p>
+    <p>Your inquiry for <strong>${studyName} (${abbr?.toUpperCase() ?? ''})</strong> has been reviewed and approved by the I3H team.</p>
+    <p>To proceed, please review and sign each of the following documents. Each link is unique to you and expires in <strong>48 hours</strong>.</p>
+    <table style="width:100%;border-collapse:collapse;margin:24px 0;">
+      ${linkRows}
+    </table>
+    <p style="font-size:0.82rem;color:#888;">Links expire in 48 hours. If any expire before you finish, you can request a new link from your I3H contact.</p>
+    <p>Best regards,<br>The I3H Operations Team</p>
+  </div>
+  <div style="text-align:center;padding:20px;font-size:12px;color:#aaa;">
+    <p>These links are unique to you. Do not forward this email.</p>
+    <p>&copy; ${new Date().getFullYear()} Penn Institute for Immunology &amp; Immune Health</p>
+  </div>
+</div>`
+}

--- a/server/api/admin/decline-inquiry.post.ts
+++ b/server/api/admin/decline-inquiry.post.ts
@@ -1,0 +1,22 @@
+import { serverSupabaseServiceRole } from '#supabase/server'
+
+export default defineEventHandler(async (event) => {
+  const { inquiryId } = await readBody(event)
+
+  if (!inquiryId) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing inquiryId' })
+  }
+
+  const supabase = serverSupabaseServiceRole(event)
+
+  const { error } = await supabase
+    .from('inquiries')
+    .update({ status: 'Declined' })
+    .eq('id', inquiryId)
+
+  if (error) {
+    throw createError({ statusCode: 500, statusMessage: 'Failed to update inquiry' })
+  }
+
+  return { success: true }
+})

--- a/server/api/admin/send-sign-link.post.ts
+++ b/server/api/admin/send-sign-link.post.ts
@@ -1,0 +1,96 @@
+import { serverSupabaseServiceRole } from '#supabase/server'
+import { createSignToken } from '~/server/utils/signing'
+
+const VALID_AGREEMENT_IDS = ['ua', 'rs', 'lv', 'psa']
+const AGREEMENT_NAMES: Record<string, string> = {
+  ua: 'Usage Agreement',
+  rs: 'Rate Schedule',
+  lv: 'LabVantage Access Agreement',
+  psa: 'Professional Services Agreement',
+}
+
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
+  const body = await readBody(event)
+  const { studyId, agreementId } = body
+
+  if (!studyId || !agreementId) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing studyId or agreementId' })
+  }
+  if (!VALID_AGREEMENT_IDS.includes(agreementId)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid agreement ID' })
+  }
+  if (!config.signingSecret) {
+    throw createError({ statusCode: 500, statusMessage: 'Signing secret not configured' })
+  }
+
+  const supabase = serverSupabaseServiceRole(event)
+
+  const { data: study, error } = await supabase
+    .from('studies')
+    .select('name, abbreviation, pi')
+    .eq('id', studyId)
+    .single()
+
+  if (error || !study) {
+    throw createError({ statusCode: 404, statusMessage: 'Study not found' })
+  }
+
+  const pi = study.pi as { name: string; email: string }
+  const token = createSignToken(studyId, agreementId, pi.email, config.signingSecret)
+  const { origin } = getRequestURL(event)
+  const signUrl = `${origin}/admin/sign/${studyId}-${agreementId}?token=${token}`
+  const agreementName = AGREEMENT_NAMES[agreementId] ?? 'Agreement'
+
+  await $fetch('https://api.mailersend.com/v1/email', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${config.mailersendApiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: {
+      from: { email: config.mailersendFromEmail, name: config.mailersendFromName },
+      to: [{ email: pi.email, name: pi.name }],
+      subject: `Action required: Please sign the ${study.name} ${agreementName}`,
+      html: buildEmail(pi.name, study.name, study.abbreviation as string, agreementName, signUrl),
+    },
+  })
+
+  const sentDate = new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+  await supabase
+    .from('agreements')
+    .update({ sent_date: sentDate })
+    .eq('study_id', studyId)
+    .eq('id', agreementId)
+
+  return { success: true, sentDate }
+})
+
+function buildEmail(piName: string, studyName: string, abbr: string, agreementName: string, signUrl: string): string {
+  return `
+<div style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;max-width:600px;margin:0 auto;color:#333;line-height:1.6;">
+  <div style="background:#011F5B;padding:20px;text-align:center;">
+    <h1 style="color:#fff;margin:0;font-size:22px;">Signature Requested · I3H</h1>
+  </div>
+  <div style="padding:30px;border:1px solid #e0e0e0;border-top:none;">
+    <p>Dear ${piName},</p>
+    <p>The Institute for Immunology &amp; Immune Health requires your signature on the
+    <strong>${agreementName}</strong> for study <strong>${studyName} (${abbr.toUpperCase()})</strong>.</p>
+    <p>Please review and sign the document using the button below. This link expires in <strong>48 hours</strong>.</p>
+    <div style="text-align:center;margin:32px 0;">
+      <a href="${signUrl}"
+         style="background:#011F5B;color:#fff;padding:14px 28px;border-radius:6px;text-decoration:none;font-weight:600;font-size:15px;">
+        Review &amp; Sign Document →
+      </a>
+    </div>
+    <p style="font-size:0.82rem;color:#888;">If the button doesn't work, copy this link into your browser:<br>
+      <a href="${signUrl}" style="color:#011F5B;word-break:break-all;">${signUrl}</a>
+    </p>
+    <p>Best regards,<br>The I3H Operations Team</p>
+  </div>
+  <div style="text-align:center;padding:20px;font-size:12px;color:#aaa;">
+    <p>This link is unique to you and expires in 48 hours. Do not forward it.</p>
+    <p>&copy; ${new Date().getFullYear()} Penn Institute for Immunology &amp; Immune Health</p>
+  </div>
+</div>`
+}

--- a/server/api/admin/sign-agreement.post.ts
+++ b/server/api/admin/sign-agreement.post.ts
@@ -1,0 +1,92 @@
+import { serverSupabaseServiceRole } from '#supabase/server'
+import { verifySignToken } from '~/server/utils/signing'
+
+const VALID_AGREEMENT_IDS = ['ua', 'rs', 'lv', 'psa']
+
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig()
+  const body = await readBody(event)
+  const { studyId, agreementId, signerName, signerEmail, token } = body
+
+  if (!studyId || !agreementId || !signerName || !signerEmail) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing required fields' })
+  }
+  if (!VALID_AGREEMENT_IDS.includes(agreementId)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid agreement ID' })
+  }
+
+  if (!token) {
+    throw createError({ statusCode: 401, statusMessage: 'Missing signing token — use the secure link from your email' })
+  }
+  try {
+    const payload = verifySignToken(token, config.signingSecret)
+    if (payload.studyId !== studyId || payload.agreementId !== agreementId) {
+      throw new Error('token mismatch')
+    }
+  }
+  catch {
+    throw createError({ statusCode: 401, statusMessage: 'Invalid or expired signing link — please request a new one' })
+  }
+
+  const supabase = serverSupabaseServiceRole(event)
+
+  // Verify agreement exists and is still pending
+  const { data: existing, error: fetchErr } = await supabase
+    .from('agreements')
+    .select('status')
+    .eq('study_id', studyId)
+    .eq('id', agreementId)
+    .single()
+
+  if (fetchErr || !existing) {
+    throw createError({ statusCode: 404, statusMessage: 'Agreement not found' })
+  }
+  if (existing.status === 'Signed') {
+    throw createError({ statusCode: 409, statusMessage: 'Agreement already signed' })
+  }
+
+  const now = new Date()
+  const signedDate = now.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+    + ' at ' + now.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
+
+  const { error: updateErr } = await supabase
+    .from('agreements')
+    .update({ status: 'Signed', signed_by: signerName, signed_date: signedDate, signed_email: signerEmail })
+    .eq('study_id', studyId)
+    .eq('id', agreementId)
+
+  if (updateErr) {
+    throw createError({ statusCode: 500, statusMessage: 'Failed to update agreement' })
+  }
+
+  // Check whether all 4 agreements for this study are now signed
+  const { data: allAgreements } = await supabase
+    .from('agreements')
+    .select('status')
+    .eq('study_id', studyId)
+
+  const allSigned = allAgreements?.length === 4 && allAgreements.every(a => a.status === 'Signed')
+
+  if (allSigned) {
+    const { data: study } = await supabase
+      .from('studies')
+      .select('lifecycle')
+      .eq('id', studyId)
+      .single()
+
+    if (study) {
+      const lifecycle = (study.lifecycle as Array<{ label: string; date: string; status: string }>).map((step, i) => {
+        if (i === 4) return { ...step, date: 'today', status: 'done' }
+        if (i === 5) return { ...step, date: 'in progress', status: 'active' }
+        return step
+      })
+
+      await supabase
+        .from('studies')
+        .update({ is_locked: false, stage: 'Processing', lifecycle })
+        .eq('id', studyId)
+    }
+  }
+
+  return { success: true, signedDate, allSigned: !!allSigned }
+})

--- a/server/api/submit-intake.post.ts
+++ b/server/api/submit-intake.post.ts
@@ -1,4 +1,28 @@
 import { defineEventHandler, readBody, createError } from 'h3'
+import { serverSupabaseServiceRole } from '#supabase/server'
+
+const SAMPLE_TYPE_LABELS: Record<string, string> = {
+  'fresh-blood': 'Fresh whole blood',
+  'stored-pbmc': 'Stored PBMCs (cryopreserved)',
+  'tissue': 'Tissue',
+  'other': 'Other',
+}
+const PHLEBOTOMY_LABELS: Record<string, string> = {
+  'ih-campus': 'IH phlebotomist on campus',
+  'remote': 'Remote phlebotomy needed',
+  'self-collect': 'Study team will collect and transfer',
+  'stored': 'N/A – using stored samples',
+}
+const METADATA_LABELS: Record<string, string> = {
+  redcap: 'REDCap',
+  other: 'Other system',
+  tbd: 'To be discussed',
+}
+const AFFILIATION_LABELS: Record<string, string> = {
+  internal: 'Internal',
+  external: 'External',
+  industry: 'Industry',
+}
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
@@ -12,7 +36,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const { form, estimatedTotal, totalSamples, servicesText } = body
+  const { form, estimatedTotal, totalSamples, servicesText, servicesDetail } = body
 
   if (!form || !form.piEmail) {
     throw createError({
@@ -72,8 +96,55 @@ export default defineEventHandler(async (event) => {
     </div>
   `
 
+  // 1. Save to Supabase first — if this fails the whole request fails before emails are sent
+  const supabase = serverSupabaseServiceRole(event)
+  const submittedDate = new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
+  const affiliationOrg = form.affiliation === 'internal'
+    ? 'University of Pennsylvania'
+    : (form.externalInstitution || '')
+
+  const initialNotes = form.notes
+    ? [{ author: form.principalInvestigator, date: submittedDate, text: form.notes }]
+    : []
+
+  const { error: dbError } = await supabase.from('inquiries').insert({
+    id: crypto.randomUUID(),
+    study_name: form.projectName,
+    abbreviation: form.acronym || null,
+    status: 'New',
+    submitted_date: submittedDate,
+    submitted_relative: 'just now',
+    objectives: form.objectives,
+    pi: { name: form.principalInvestigator, email: form.piEmail },
+    study_lead: form.projectLead ? { name: form.projectLead, email: form.leadEmail } : null,
+    affiliation: AFFILIATION_LABELS[form.affiliation] || 'External',
+    affiliation_org: affiliationOrg,
+    irb: form.irbNumber || null,
+    cohort_subjects: form.subjectCount,
+    cohort_timepoints: form.timepointCount,
+    services: servicesText,
+    services_detail: servicesDetail || [],
+    estimate: estimatedTotal || null,
+    sample_type: SAMPLE_TYPE_LABELS[form.sampleType] || form.sampleType || null,
+    phlebotomy: PHLEBOTOMY_LABELS[form.phlebotomyNeeds] || form.phlebotomyNeeds || null,
+    metadata: METADATA_LABELS[form.metadataPlan] || form.metadataPlan || null,
+    notes: initialNotes,
+    feasibility: [
+      { label: 'IRB protocol reviewed', checked: false },
+      { label: 'Sample type confirmed viable', checked: false },
+      { label: 'Cohort scope reviewed', checked: false },
+      { label: 'Service capacity confirmed', checked: false },
+      { label: 'Budget / account code verified', checked: false },
+    ],
+  })
+
+  if (dbError) {
+    console.error('Supabase insert error:', dbError)
+    throw createError({ statusCode: 500, statusMessage: 'Failed to save inquiry' })
+  }
+
+  // 2. Send emails
   try {
-    // Send to PI and Lead
     const recipients = [
       { email: form.piEmail, name: form.principalInvestigator },
     ]
@@ -92,8 +163,6 @@ export default defineEventHandler(async (event) => {
       },
     })
 
-    // 2. Send submission email to Admin in JSON
-    const adminEmail = config.adminEmail
     const submissionData = {
       form,
       totalSamples,
@@ -106,20 +175,17 @@ export default defineEventHandler(async (event) => {
       headers: commonHeaders,
       body: {
         from: { email: config.mailersendFromEmail, name: config.mailersendFromName },
-        to: [{ email: adminEmail, name: 'Immune Health Admin' }],
+        to: [{ email: config.adminEmail, name: 'Immune Health Admin' }],
         subject: `[SUBMISSION] ${form.projectName}`,
         text: JSON.stringify(submissionData, null, 2),
       },
     })
-
-    return { success: true }
   }
   catch (error: unknown) {
     const err = error as { data?: unknown; message?: string }
     console.error('Error sending email via MailerSend:', err.data || err.message)
-    throw createError({
-      statusCode: 500,
-      statusMessage: 'Failed to send emails',
-    })
+    throw createError({ statusCode: 500, statusMessage: 'Failed to send confirmation emails' })
   }
+
+  return { success: true }
 })

--- a/server/utils/signing.ts
+++ b/server/utils/signing.ts
@@ -1,0 +1,41 @@
+import { createHmac } from 'node:crypto'
+
+export interface SignTokenPayload {
+  studyId: string
+  agreementId: string
+  piEmail: string
+  exp: number
+}
+
+const b64 = (s: string) => Buffer.from(s).toString('base64url')
+const decode = (s: string) => Buffer.from(s, 'base64url').toString('utf8')
+const HEADER = b64(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+
+export function createSignToken(
+  studyId: string,
+  agreementId: string,
+  piEmail: string,
+  secret: string,
+  ttlSeconds = 172800, // 48 hours
+): string {
+  const payload: SignTokenPayload = {
+    studyId,
+    agreementId,
+    piEmail,
+    exp: Math.floor(Date.now() / 1000) + ttlSeconds,
+  }
+  const body = b64(JSON.stringify(payload))
+  const sig = createHmac('sha256', secret).update(`${HEADER}.${body}`).digest('base64url')
+  return `${HEADER}.${body}.${sig}`
+}
+
+export function verifySignToken(token: string, secret: string): SignTokenPayload {
+  const parts = token.split('.')
+  if (parts.length !== 3) throw new Error('malformed token')
+  const [header, body, sig] = parts
+  const expected = createHmac('sha256', secret).update(`${header}.${body}`).digest('base64url')
+  if (sig !== expected) throw new Error('invalid signature')
+  const payload = JSON.parse(decode(body)) as SignTokenPayload
+  if (payload.exp < Math.floor(Date.now() / 1000)) throw new Error('token expired')
+  return payload
+}

--- a/stores/admin.ts
+++ b/stores/admin.ts
@@ -1,0 +1,287 @@
+import { defineStore } from 'pinia'
+
+export type InquiryStatus = 'New' | 'In Review' | 'Approved' | 'Declined' | 'Stale'
+export type StudyStage = 'Review' | 'Agreement' | 'Awaiting Signature' | 'Processing' | 'Complete'
+export type Affiliation = 'Internal' | 'External' | 'Industry'
+
+export interface Inquiry {
+  id: string
+  studyName: string
+  abbreviation: string
+  submittedDate: string
+  submittedRelative: string
+  isStale?: boolean
+  objectives: string
+  pi: { name: string; email: string }
+  studyLead?: { name: string; email: string }
+  affiliation: Affiliation
+  affiliationOrg: string
+  irb: string
+  cohortSubjects: number
+  cohortTimepoints: number
+  services: string
+  servicesDetail: Array<{ name: string; qty: number; rate: string }>
+  status: InquiryStatus
+  estimate?: number
+  sampleType?: string
+  phlebotomy?: string
+  metadata?: string
+  notes: Array<{ author: string; date: string; text: string }>
+  feasibility: Array<{ label: string; checked: boolean }>
+}
+
+export interface Agreement {
+  id: string
+  name: string
+  description: string
+  status: 'Signed' | 'Pending'
+  signedBy?: string
+  signedDate?: string
+  signedEmail?: string
+  sentDate?: string
+  reminderDate?: string
+}
+
+export interface ActivityItem {
+  dotClass: string
+  title: string
+  date: string
+  author?: string
+  note?: string
+}
+
+export interface Study {
+  id: string
+  name: string
+  abbreviation: string
+  pi: { name: string; email: string }
+  studyLead?: { name: string; email: string }
+  affiliation: Affiliation
+  affiliationOrg: string
+  irb: string
+  stage: StudyStage
+  agreements: Agreement[]
+  cohort: {
+    subjects: number
+    timepoints: number
+    totalSamples: number
+    processedSamples: number
+    sampleType: string
+  }
+  budget: {
+    committed: number
+    invoiced: number
+    remaining: number
+    pctInvoiced: number
+    accountCode?: string
+    billingContact?: string
+    lines: Array<{ service: string; rate: number; planned: number; completed: number; committed: number; invoiced: number }>
+  }
+  integrations: { redcap?: string; labvantage?: string; pennsieve?: string }
+  startedDate?: string
+  department?: string
+  objectives?: string
+  phlebotomy?: string
+  metadata?: string
+  activity: ActivityItem[]
+  lifecycle: Array<{ label: string; date: string; status: 'done' | 'active' | 'pending' }>
+  updatedRelative: string
+  isLocked: boolean
+  quickStats?: { samplesReceived: number; samplesTotal: number; cytofAcquired: number; cytofTotal: number; qcPassed: number; qcTotal: number; invoicedYtd: number }
+}
+
+function mapInquiry(row: Record<string, unknown>): Inquiry {
+  return {
+    id: row.id as string,
+    studyName: row.study_name as string,
+    abbreviation: row.abbreviation as string,
+    submittedDate: row.submitted_date as string,
+    submittedRelative: row.submitted_relative as string,
+    isStale: row.is_stale as boolean,
+    objectives: row.objectives as string,
+    pi: row.pi as { name: string; email: string },
+    studyLead: row.study_lead as { name: string; email: string } | undefined,
+    affiliation: row.affiliation as Affiliation,
+    affiliationOrg: row.affiliation_org as string,
+    irb: row.irb as string,
+    cohortSubjects: row.cohort_subjects as number,
+    cohortTimepoints: row.cohort_timepoints as number,
+    services: row.services as string,
+    servicesDetail: (row.services_detail as Array<{ name: string; qty: number; rate: string }>) || [],
+    status: row.status as InquiryStatus,
+    estimate: row.estimate as number | undefined,
+    sampleType: row.sample_type as string | undefined,
+    phlebotomy: row.phlebotomy as string | undefined,
+    metadata: row.metadata as string | undefined,
+    notes: (row.notes as Array<{ author: string; date: string; text: string }>) || [],
+    feasibility: (row.feasibility as Array<{ label: string; checked: boolean }>) || [],
+  }
+}
+
+function mapStudy(row: Record<string, unknown>, agreements: Agreement[]): Study {
+  return {
+    id: row.id as string,
+    name: row.name as string,
+    abbreviation: row.abbreviation as string,
+    pi: row.pi as { name: string; email: string },
+    studyLead: row.study_lead as { name: string; email: string } | undefined,
+    affiliation: row.affiliation as Affiliation,
+    affiliationOrg: row.affiliation_org as string,
+    irb: row.irb as string,
+    stage: row.stage as StudyStage,
+    isLocked: row.is_locked as boolean,
+    agreements,
+    cohort: row.cohort as Study['cohort'],
+    budget: row.budget as Study['budget'],
+    integrations: (row.integrations as Study['integrations']) || {},
+    startedDate: row.started_date as string | undefined,
+    department: row.department as string | undefined,
+    objectives: row.objectives as string | undefined,
+    phlebotomy: row.phlebotomy as string | undefined,
+    metadata: row.metadata_desc as string | undefined,
+    activity: (row.activity as ActivityItem[]) || [],
+    lifecycle: (row.lifecycle as Study['lifecycle']) || [],
+    updatedRelative: row.updated_relative as string,
+    quickStats: row.quick_stats as Study['quickStats'],
+  }
+}
+
+function mapAgreement(row: Record<string, unknown>): Agreement {
+  return {
+    id: row.id as string,
+    name: row.name as string,
+    description: row.description as string,
+    status: row.status as 'Signed' | 'Pending',
+    signedBy: row.signed_by as string | undefined,
+    signedDate: row.signed_date as string | undefined,
+    signedEmail: row.signed_email as string | undefined,
+    sentDate: row.sent_date as string | undefined,
+    reminderDate: row.reminder_date as string | undefined,
+  }
+}
+
+export const useAdminStore = defineStore('admin', {
+  state: () => ({
+    user: {
+      name: 'Lori Guercio',
+      email: 'lguercio@pennmedicine.upenn.edu',
+      initials: 'LG',
+      role: 'Admin · Operations Lead',
+    },
+    inquiries: [] as Inquiry[],
+    studies: [] as Study[],
+    isLoading: false,
+    isInitialized: false,
+  }),
+
+  getters: {
+    signedInAgreementsCount: (state) => (studyId: string) => {
+      const study = state.studies.find(s => s.id === studyId)
+      if (!study) return 0
+      return study.agreements.filter(a => a.status === 'Signed').length
+    },
+
+    newInquiriesCount: (state) => state.inquiries.filter(i => i.status === 'New' || i.status === 'Stale').length,
+
+    studiesByStage: (state) => (stage: StudyStage) => state.studies.filter(s => s.stage === stage),
+  },
+
+  actions: {
+    async loadAll() {
+      if (this.isLoading) return
+      this.isLoading = true
+      try {
+        await Promise.all([this.loadInquiries(), this.loadStudies()])
+        this.isInitialized = true
+      }
+      finally {
+        this.isLoading = false
+      }
+    },
+
+    async loadInquiries() {
+      const supabase = useSupabaseClient()
+      const { data, error } = await supabase
+        .from('inquiries')
+        .select('*')
+        .order('created_at', { ascending: false })
+      if (error) throw error
+      this.inquiries = (data || []).map(row => mapInquiry(row as Record<string, unknown>))
+    },
+
+    async loadStudies() {
+      const supabase = useSupabaseClient()
+      const { data, error } = await supabase
+        .from('studies')
+        .select('*, agreements(*)')
+        .order('updated_at', { ascending: false })
+      if (error) throw error
+
+      this.studies = (data || []).map((row) => {
+        const agreementsRaw = (row.agreements as Array<Record<string, unknown>>) || []
+        const agreementOrder = ['ua', 'rs', 'lv', 'psa']
+        const agreements = agreementOrder
+          .map(id => agreementsRaw.find(a => a.id === id))
+          .filter(Boolean)
+          .map(a => mapAgreement(a as Record<string, unknown>))
+        return mapStudy(row as Record<string, unknown>, agreements)
+      })
+    },
+
+    async signAgreement(studyId: string, agreementId: string, signerName: string, signerEmail: string) {
+      const supabase = useSupabaseClient()
+      const now = new Date()
+      const signedDate = now.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+        + ' at ' + now.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
+
+      const { error } = await supabase
+        .from('agreements')
+        .update({ status: 'Signed', signed_by: signerName, signed_date: signedDate, signed_email: signerEmail })
+        .eq('study_id', studyId)
+        .eq('id', agreementId)
+
+      if (error) throw error
+
+      // Update local state immediately (no full reload needed)
+      const study = this.studies.find(s => s.id === studyId)
+      if (study) {
+        const agreement = study.agreements.find(a => a.id === agreementId)
+        if (agreement) {
+          agreement.status = 'Signed'
+          agreement.signedBy = signerName
+          agreement.signedDate = signedDate
+          agreement.signedEmail = signerEmail
+        }
+
+        const allSigned = study.agreements.every(a => a.status === 'Signed')
+        if (allSigned) {
+          await supabase
+            .from('studies')
+            .update({
+              is_locked: false,
+              stage: 'Processing',
+              lifecycle: study.lifecycle.map((step, i) => {
+                if (i === 4) return { ...step, date: 'today', status: 'done' }
+                if (i === 5) return { ...step, date: 'in progress', status: 'active' }
+                return step
+              }),
+            })
+            .eq('id', studyId)
+
+          study.isLocked = false
+          study.stage = 'Processing'
+          study.lifecycle[4] = { label: 'Activated', date: 'today', status: 'done' }
+          study.lifecycle[5] = { label: 'Processing', date: 'in progress', status: 'active' }
+        }
+      }
+    },
+
+    async logout() {
+      const supabase = useSupabaseClient()
+      await supabase.auth.signOut()
+      this.inquiries = []
+      this.studies = []
+      this.isInitialized = false
+    },
+  },
+})

--- a/supabase/migrations/001_create_schema.sql
+++ b/supabase/migrations/001_create_schema.sql
@@ -1,0 +1,116 @@
+-- ============================================================
+-- Admin Console Schema
+-- Run this in the Supabase SQL editor (Project → SQL Editor)
+-- ============================================================
+
+-- Inquiries: one row per PI intake submission
+create table if not exists inquiries (
+  id                 text primary key,
+  study_name         text not null,
+  abbreviation       text,
+  status             text not null default 'New',
+  submitted_date     text,
+  submitted_relative text,
+  is_stale           boolean default false,
+  objectives         text,
+  pi                 jsonb,           -- { name, email }
+  study_lead         jsonb,           -- { name, email }
+  affiliation        text,
+  affiliation_org    text,
+  irb                text,
+  cohort_subjects    integer,
+  cohort_timepoints  integer,
+  services           text,
+  services_detail    jsonb default '[]'::jsonb,
+  estimate           numeric,
+  sample_type        text,
+  phlebotomy         text,
+  metadata           text,
+  notes              jsonb default '[]'::jsonb,
+  feasibility        jsonb default '[]'::jsonb,
+  created_at         timestamptz default now(),
+  updated_at         timestamptz default now()
+);
+
+-- Studies: activated research studies
+create table if not exists studies (
+  id               text primary key,
+  name             text not null,
+  abbreviation     text,
+  pi               jsonb,   -- { name, email }
+  study_lead       jsonb,   -- { name, email }
+  affiliation      text,
+  affiliation_org  text,
+  irb              text,
+  stage            text not null default 'Inquiry',
+  is_locked        boolean default false,
+  cohort           jsonb,   -- { subjects, timepoints, totalSamples, processedSamples, sampleType }
+  budget           jsonb,   -- { committed, invoiced, remaining, pctInvoiced, accountCode, billingContact, lines[] }
+  integrations     jsonb default '{}'::jsonb,  -- { redcap, labvantage, pennsieve }
+  started_date     text,
+  department       text,
+  objectives       text,
+  phlebotomy       text,
+  metadata_desc    text,
+  lifecycle        jsonb default '[]'::jsonb,  -- [{ label, date, status }]
+  updated_relative text,
+  quick_stats      jsonb,   -- { samplesReceived, samplesTotal, cytofAcquired, ... }
+  activity         jsonb default '[]'::jsonb,  -- [{ dotClass, title, date, author, note }]
+  created_at       timestamptz default now(),
+  updated_at       timestamptz default now()
+);
+
+-- Agreements: one row per (study, agreement_type) — updated individually for signing
+create table if not exists agreements (
+  id             text not null,
+  study_id       text not null references studies(id) on delete cascade,
+  name           text not null,
+  description    text,
+  status         text not null default 'Pending',
+  signed_by      text,
+  signed_date    text,
+  signed_email   text,
+  sent_date      text,
+  reminder_date  text,
+  primary key (study_id, id)
+);
+
+-- ============================================================
+-- Row Level Security
+-- All tables: authenticated users (admin staff) have full access
+-- The PI signing flow uses a service-role server API route (bypasses RLS)
+-- ============================================================
+
+alter table inquiries  enable row level security;
+alter table studies    enable row level security;
+alter table agreements enable row level security;
+
+create policy "Admin full access on inquiries"
+  on inquiries for all
+  using (auth.role() = 'authenticated')
+  with check (auth.role() = 'authenticated');
+
+create policy "Admin full access on studies"
+  on studies for all
+  using (auth.role() = 'authenticated')
+  with check (auth.role() = 'authenticated');
+
+create policy "Admin full access on agreements"
+  on agreements for all
+  using (auth.role() = 'authenticated')
+  with check (auth.role() = 'authenticated');
+
+-- ============================================================
+-- updated_at trigger
+-- ============================================================
+
+create or replace function handle_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger inquiries_updated_at  before update on inquiries  for each row execute procedure handle_updated_at();
+create trigger studies_updated_at    before update on studies    for each row execute procedure handle_updated_at();

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,195 @@
+-- ============================================================
+-- Seed data — run after 001_create_schema.sql
+-- Populates mock studies, agreements, and inquiries
+-- ============================================================
+
+-- INQUIRIES
+
+insert into inquiries (id, study_name, abbreviation, status, submitted_date, submitted_relative, is_stale, objectives, pi, study_lead, affiliation, affiliation_org, irb, cohort_subjects, cohort_timepoints, services, services_detail, estimate, sample_type, phlebotomy, metadata, notes, feasibility) values
+(
+  'apex-merck', 'APEX-Merck', 'APEX', 'New', 'May 12, 2026', '4 hours ago', false,
+  'Discovery of immune correlates of response to PD-1 checkpoint inhibitor therapy in NSCLC. Primary endpoint: CD8+ T-cell exhaustion markers at week 6 versus baseline.',
+  '{"name":"Dr. James Wilson","email":"wilson@merck.com"}',
+  '{"name":"Rachel Thompson","email":"rthompson@merck.com"}',
+  'Industry', 'Merck Research Laboratories', 'Pending — Merck IRB',
+  60, 2, 'CyTOF, Tier 1 analysis',
+  '[{"name":"PBMC processing","qty":120,"rate":"$450"},{"name":"CyTOF MDIPA","qty":120,"rate":"no quote — contact"},{"name":"Tier 1 analysis","qty":120,"rate":"$50"}]',
+  58250, 'Fresh whole blood', 'Remote — collected at Merck sites, shipped overnight', 'REDCap (Merck-hosted instance)',
+  '[{"author":"Lori Guercio","date":"May 12 · 11:08 AM","text":"CyTOF capacity check w/ Hannah — can absorb in early Q3 batch. Need MSA before agreement package goes out. Routing to legal."}]',
+  '[{"label":"Volume fits processing pipeline capacity","checked":true},{"label":"Sample type compatible (fresh whole blood)","checked":true},{"label":"IRB approval confirmed","checked":false},{"label":"Industry rate sheet reviewed","checked":false},{"label":"Master Service Agreement in place","checked":false}]'
+),
+(
+  'cardia-penn', 'CARDIA-Penn', 'CARDIA', 'New', 'May 11, 2026', '1 day ago', false,
+  'Characterization of immune cell dynamics in cardiac immunometabolism. Primary endpoint: NK cell activation state and macrophage polarization at baseline vs. post-intervention.',
+  '{"name":"Dr. Adamski","email":"adamski@pennmedicine.upenn.edu"}',
+  null,
+  'Internal', 'Perelman School of Medicine', '852041',
+  24, 3, 'PBMC processing, CyTOF, banking',
+  '[{"name":"PBMC processing","qty":72,"rate":"$300"},{"name":"CyTOF MDIPA","qty":72,"rate":"$325"},{"name":"Sample banking","qty":72,"rate":"$50"}]',
+  47880, 'Fresh whole blood', 'IH phlebotomist on Penn campus', 'REDCap (Penn-hosted)',
+  '[]',
+  '[{"label":"Volume fits processing pipeline capacity","checked":true},{"label":"Sample type compatible (fresh whole blood)","checked":true},{"label":"IRB approval confirmed","checked":true},{"label":"Penn internal rate sheet reviewed","checked":false},{"label":"Phlebotomy scheduling confirmed","checked":false}]'
+),
+(
+  'resolve-ibd', 'RESOLVE-IBD', 'RESOLVE', 'New', 'May 09, 2026', '3 days ago', false,
+  'Mapping of immune signatures associated with remission in inflammatory bowel disease. Primary endpoint: Treg and Th17 balance across 4 longitudinal timepoints.',
+  '{"name":"Dr. Lakshmi","email":"lakshmi@pennmedicine.upenn.edu"}',
+  null,
+  'Internal', 'Division of Gastroenterology', '849912',
+  40, 4, 'PBMC, CyTOF, Tier 1 + Tier 2',
+  '[{"name":"PBMC processing","qty":160,"rate":"$300"},{"name":"CyTOF MDIPA","qty":160,"rate":"$325"},{"name":"Tier 1 analysis","qty":160,"rate":"$50"},{"name":"Tier 2 analysis","qty":80,"rate":"$120"}]',
+  117600, 'Fresh whole blood', 'IH phlebotomist on Penn campus', 'REDCap · Project ID 24-resolve-ibd',
+  '[]',
+  '[{"label":"Volume fits processing pipeline capacity","checked":false},{"label":"Sample type compatible (fresh whole blood)","checked":true},{"label":"IRB approval confirmed","checked":true},{"label":"Penn internal rate sheet reviewed","checked":false},{"label":"Tier 2 analysis capacity available","checked":false}]'
+),
+(
+  'vector-chop', 'VECTOR-CHOP', 'VECTOR', 'Stale', 'May 06, 2026', '6 days ago', true,
+  'Longitudinal characterization of B-cell and T-cell responses to pediatric vaccine series. Primary endpoint: germinal center B-cell expansion at days 7, 14, and 28.',
+  '{"name":"Dr. Bhattacharya","email":"bhatt@email.chop.edu"}',
+  null,
+  'External', 'Children''s Hospital of Philadelphia', '21-018774',
+  18, 5, 'PBMC, CyTOF',
+  '[{"name":"PBMC processing","qty":90,"rate":"$375"},{"name":"CyTOF MDIPA","qty":90,"rate":"$350"}]',
+  65250, 'Fresh whole blood', 'Remote — collected at CHOP, shipped overnight', 'REDCap (CHOP-hosted)',
+  '[]',
+  '[{"label":"Volume fits processing pipeline capacity","checked":true},{"label":"Sample type compatible (fresh whole blood)","checked":true},{"label":"IRB approval confirmed (CHOP & Penn)","checked":false},{"label":"External rate sheet reviewed","checked":false},{"label":"Data sharing agreement drafted","checked":false}]'
+);
+
+
+-- STUDIES
+
+insert into studies (id, name, abbreviation, pi, study_lead, affiliation, affiliation_org, irb, stage, is_locked, cohort, budget, integrations, started_date, department, objectives, phlebotomy, metadata_desc, lifecycle, updated_relative, quick_stats, activity) values
+(
+  'bhb-colcan', 'BHB ColCan', 'BHB',
+  '{"name":"Dr. Katona","email":"katona@pennmedicine.upenn.edu"}',
+  '{"name":"John Smith","email":"jsmith@pennmedicine.upenn.edu"}',
+  'Internal', 'Gastroenterology, Perelman School of Medicine', '850567',
+  'Awaiting Signature', true,
+  '{"subjects":20,"timepoints":2,"totalSamples":40,"processedSamples":0,"sampleType":"Fresh whole blood"}',
+  '{"committed":27250,"invoiced":16400,"remaining":10850,"pctInvoiced":60,"accountCode":"400-4661-1-605016-xxxx-2459-0000","billingContact":"khas@pennmedicine.upenn.edu","lines":[{"service":"Consultation","rate":250,"planned":1,"completed":1,"committed":250,"invoiced":250},{"service":"Blood processing (PBMC)","rate":300,"planned":40,"completed":32,"committed":12000,"invoiced":9600},{"service":"CyTOF MDIPA","rate":325,"planned":40,"completed":18,"committed":13000,"invoiced":5850},{"service":"Tier 1 analysis","rate":50,"planned":40,"completed":14,"committed":2000,"invoiced":700}]}',
+  '{"redcap":"23-bhb-pcc","labvantage":"STU-2026-014","pennsieve":"N:dataset:7a44…0c18"}',
+  'Jan 15, 2026', 'Division of Gastroenterology · Perelman School of Medicine',
+  'Investigation of beta-hydroxybutyrate (BHB) supplementation as a chemopreventive intervention for colorectal cancer.',
+  'IH phlebotomist on Penn campus', 'REDCap · Project ID 23-bhb-pcc · synced via export',
+  '[{"label":"Inquiry","date":"Jan 15","status":"done"},{"label":"Review","date":"Jan 18","status":"done"},{"label":"Approved","date":"Jan 22","status":"done"},{"label":"Agreements","date":"in progress","status":"active"},{"label":"Activated","date":"—","status":"pending"},{"label":"Processing","date":"—","status":"pending"},{"label":"Delivered","date":"—","status":"pending"}]',
+  '2h ago',
+  '{"samplesReceived":32,"samplesTotal":40,"cytofAcquired":18,"cytofTotal":40,"qcPassed":14,"qcTotal":18,"invoicedYtd":16400}',
+  '[{"dotClass":"w","title":"Reminder sent — Pennsieve Data Sharing Agreement","date":"May 08, 2026 · 9:00 AM · automated"},{"dotClass":"m","title":"Lori Guercio","date":"May 04, 2026 · 3:12 PM · internal note","note":"Spoke with John (study lead) — Dr. Katona is out of country until 5/13. Pennsieve agreement signature delayed but confirmed coming."},{"dotClass":"","title":"Pennsieve Data Sharing Agreement sent to PI","date":"May 01, 2026 · 4:32 PM"},{"dotClass":"g","title":"14 processing events logged · CyTOF batch B-2026-018","date":"Apr 28, 2026 · logged by Hannah Pham (lab ops)"},{"dotClass":"g","title":"12 samples received at drop-off","date":"Feb 17, 2026 · logged by Sara Coleman (lab ops)"},{"dotClass":"","title":"Study activated","date":"Jan 28, 2026 · LabVantage ID STU-2026-014"}]'
+),
+(
+  'prince-val', 'PRINCE-Val Asthma', 'PRINCE',
+  '{"name":"Dr. Vonderheide","email":"vonderheide@pennmedicine.upenn.edu"}',
+  null,
+  'Internal', 'Abramson Cancer Center', '842118',
+  'Complete', false,
+  '{"subjects":45,"timepoints":3,"totalSamples":135,"processedSamples":135,"sampleType":"Fresh whole blood"}',
+  '{"committed":91800,"invoiced":91800,"remaining":0,"pctInvoiced":100,"billingContact":"billing@pennmedicine.upenn.edu","lines":[{"service":"Consultation","rate":250,"planned":1,"completed":1,"committed":250,"invoiced":250},{"service":"Blood processing (PBMC)","rate":300,"planned":135,"completed":135,"committed":40500,"invoiced":40500},{"service":"CyTOF MDIPA","rate":325,"planned":135,"completed":135,"committed":43875,"invoiced":43875},{"service":"Tier 1 analysis","rate":50,"planned":135,"completed":135,"committed":6750,"invoiced":6750}]}',
+  '{"redcap":"22-prince-val","labvantage":"STU-2025-007","pennsieve":"N:dataset:3f12…aa42"}',
+  'Feb 15, 2025', 'Abramson Cancer Center',
+  'Longitudinal profiling of asthma-related immune phenotypes following PRINCE checkpoint inhibitor protocol.',
+  'IH phlebotomist on Penn campus', 'REDCap · Project ID 22-prince-val',
+  '[{"label":"Inquiry","date":"Feb 01","status":"done"},{"label":"Review","date":"Feb 05","status":"done"},{"label":"Approved","date":"Feb 10","status":"done"},{"label":"Agreements","date":"Feb 12","status":"done"},{"label":"Activated","date":"Feb 15","status":"done"},{"label":"Processing","date":"Dec 18","status":"done"},{"label":"Delivered","date":"Jan 15","status":"done"}]',
+  '3d ago', null,
+  '[{"dotClass":"g","title":"All samples delivered on Pennsieve","date":"Jan 15, 2026 · N:dataset:3f12…aa42"},{"dotClass":"g","title":"135 CyTOF acquisitions complete","date":"Dec 18, 2025 · batch B-2025-041"}]'
+),
+(
+  'surge-christie', 'SURGE-Christie', 'SURGE',
+  '{"name":"Dr. Christie","email":"christie@pennmedicine.upenn.edu"}',
+  null,
+  'Internal', 'Perelman School of Medicine', '850991',
+  'Agreement', true,
+  '{"subjects":30,"timepoints":2,"totalSamples":60,"processedSamples":0,"sampleType":"Fresh whole blood"}',
+  '{"committed":41000,"invoiced":0,"remaining":41000,"pctInvoiced":0,"billingContact":"billing@pennmedicine.upenn.edu","lines":[{"service":"Consultation","rate":250,"planned":1,"completed":0,"committed":250,"invoiced":0},{"service":"Blood processing (PBMC)","rate":300,"planned":60,"completed":0,"committed":18000,"invoiced":0},{"service":"CyTOF MDIPA","rate":325,"planned":60,"completed":0,"committed":19500,"invoiced":0},{"service":"Tier 1 analysis","rate":50,"planned":60,"completed":0,"committed":3000,"invoiced":0}]}',
+  '{"redcap":"26-surge"}',
+  'Mar 28, 2026', 'Division of Oncology',
+  'Investigation of immune correlates of surgical response in solid tumor patients.',
+  'IH phlebotomist on Penn campus', 'REDCap · Project ID 26-surge',
+  '[{"label":"Inquiry","date":"Mar 22","status":"done"},{"label":"Review","date":"Mar 25","status":"done"},{"label":"Approved","date":"Mar 28","status":"done"},{"label":"Agreements","date":"in progress","status":"active"},{"label":"Activated","date":"—","status":"pending"},{"label":"Processing","date":"—","status":"pending"},{"label":"Delivered","date":"—","status":"pending"}]',
+  'today', null,
+  '[{"dotClass":"g","title":"Rate Schedule countersigned — Dr. Christie","date":"Apr 02, 2026 · 2:15 PM"},{"dotClass":"","title":"Agreement package sent to PI","date":"Apr 01, 2026 · 10:00 AM · MailerSend"},{"dotClass":"","title":"Intake approved","date":"Mar 28, 2026"},{"dotClass":"","title":"Intake submitted","date":"Mar 22, 2026 · via public intake form"}]'
+),
+(
+  'titan-harvard', 'TITAN-Harvard', 'TITAN',
+  '{"name":"Dr. Chen","email":"chen@harvard.edu"}',
+  null,
+  'External', 'Harvard Medical School', '22-100482',
+  'Processing', false,
+  '{"subjects":50,"timepoints":4,"totalSamples":200,"processedSamples":124,"sampleType":"Fresh whole blood"}',
+  '{"committed":124000,"invoiced":78000,"remaining":46000,"pctInvoiced":63,"billingContact":"grants@harvard.edu","lines":[{"service":"Consultation","rate":350,"planned":1,"completed":1,"committed":350,"invoiced":350},{"service":"Blood processing (PBMC)","rate":375,"planned":200,"completed":124,"committed":75000,"invoiced":46500},{"service":"CyTOF MDIPA","rate":350,"planned":200,"completed":124,"committed":70000,"invoiced":43400},{"service":"Tier 1 analysis","rate":60,"planned":200,"completed":80,"committed":12000,"invoiced":4800}]}',
+  '{"redcap":"22-titan-hms","labvantage":"STU-2025-022","pennsieve":"N:dataset:0a83…cc11"}',
+  'Nov 15, 2025', 'Department of Medicine, HMS',
+  'Longitudinal characterization of T-cell diversity and exhaustion markers in autoimmune disease cohort.',
+  'Remote — collected at HMS sites, shipped overnight', 'REDCap (HMS-hosted) · Project ID 22-titan-hms',
+  '[{"label":"Inquiry","date":"Oct 28","status":"done"},{"label":"Review","date":"Oct 31","status":"done"},{"label":"Approved","date":"Nov 02","status":"done"},{"label":"Agreements","date":"Nov 06","status":"done"},{"label":"Activated","date":"Nov 15","status":"done"},{"label":"Processing","date":"in progress","status":"active"},{"label":"Delivered","date":"—","status":"pending"}]',
+  '5h ago',
+  '{"samplesReceived":124,"samplesTotal":200,"cytofAcquired":80,"cytofTotal":200,"qcPassed":74,"qcTotal":80,"invoicedYtd":78000}',
+  '[{"dotClass":"g","title":"14 processing events logged · CyTOF batch B-2026-018","date":"May 11, 2026 · logged by Hannah Pham"},{"dotClass":"g","title":"Pennsieve dataset linked","date":"May 08, 2026 · N:dataset:0a83…cc11"},{"dotClass":"","title":"18 samples received at drop-off","date":"May 01, 2026 · logged by Sara Coleman"}]'
+),
+(
+  'immune-stanford', 'IMMUNE-Stanford', 'IMST',
+  '{"name":"Dr. Patel","email":"patel@stanford.edu"}',
+  null,
+  'External', 'Stanford University School of Medicine', '53294',
+  'Complete', false,
+  '{"subjects":35,"timepoints":3,"totalSamples":105,"processedSamples":105,"sampleType":"Fresh whole blood"}',
+  '{"committed":68400,"invoiced":68400,"remaining":0,"pctInvoiced":100,"billingContact":"grants@stanford.edu","lines":[{"service":"Consultation","rate":350,"planned":1,"completed":1,"committed":350,"invoiced":350},{"service":"Blood processing (PBMC)","rate":375,"planned":105,"completed":105,"committed":39375,"invoiced":39375},{"service":"CyTOF MDIPA","rate":350,"planned":105,"completed":105,"committed":36750,"invoiced":36750},{"service":"Tier 1 analysis","rate":60,"planned":105,"completed":105,"committed":6300,"invoiced":6300}]}',
+  '{"redcap":"25-immune-su","labvantage":"STU-2025-011","pennsieve":"N:dataset:8c41…dd90"}',
+  'Mar 20, 2025', 'Department of Medicine, Stanford',
+  'Comprehensive immune profiling of SLE patients at diagnosis, 6 months, and 12 months post-treatment.',
+  'Remote — Stanford collection sites', 'REDCap (Stanford-hosted)',
+  '[{"label":"Inquiry","date":"Mar 10","status":"done"},{"label":"Review","date":"Mar 13","status":"done"},{"label":"Approved","date":"Mar 15","status":"done"},{"label":"Agreements","date":"Mar 15","status":"done"},{"label":"Activated","date":"Mar 20","status":"done"},{"label":"Processing","date":"Jan 10","status":"done"},{"label":"Delivered","date":"Jan 28","status":"done"}]',
+  '8d ago', null,
+  '[{"dotClass":"g","title":"All data delivered on Pennsieve","date":"Jan 28, 2026"},{"dotClass":"g","title":"105 CyTOF acquisitions complete","date":"Jan 10, 2026"}]'
+),
+(
+  'nova-biogen', 'NOVA-BioGen', 'NOVA',
+  '{"name":"Dr. Martinez","email":"martinez@biogen.com"}',
+  null,
+  'Industry', 'Biogen', '24-CT-008',
+  'Processing', false,
+  '{"subjects":50,"timepoints":3,"totalSamples":150,"processedSamples":50,"sampleType":"Fresh whole blood"}',
+  '{"committed":135000,"invoiced":42500,"remaining":92500,"pctInvoiced":31,"billingContact":"researchops@biogen.com","lines":[{"service":"Consultation","rate":500,"planned":1,"completed":1,"committed":500,"invoiced":500},{"service":"Blood processing (PBMC)","rate":450,"planned":150,"completed":50,"committed":67500,"invoiced":22500},{"service":"CyTOF MDIPA","rate":425,"planned":150,"completed":50,"committed":63750,"invoiced":21250},{"service":"Tier 1 analysis","rate":60,"planned":150,"completed":50,"committed":9000,"invoiced":3000}]}',
+  '{"redcap":"24-nova-bg","labvantage":"STU-2026-008","pennsieve":"N:dataset:1b72…ef33"}',
+  'Jan 20, 2026', 'Biogen Research',
+  'Phase II biomarker study for novel MS therapeutic. Immune profiling at baseline, 3 months, and 6 months.',
+  'Remote — Biogen clinical sites, shipped overnight', 'REDCap (Biogen-hosted)',
+  '[{"label":"Inquiry","date":"Dec 12","status":"done"},{"label":"Review","date":"Dec 18","status":"done"},{"label":"Approved","date":"Jan 02","status":"done"},{"label":"Agreements","date":"Jan 07","status":"done"},{"label":"Activated","date":"Jan 20","status":"done"},{"label":"Processing","date":"in progress","status":"active"},{"label":"Delivered","date":"—","status":"pending"}]',
+  'yesterday',
+  '{"samplesReceived":50,"samplesTotal":150,"cytofAcquired":50,"cytofTotal":150,"qcPassed":47,"qcTotal":50,"invoicedYtd":42500}',
+  '[{"dotClass":"g","title":"50 samples processed — first batch complete","date":"Apr 28, 2026 · CyTOF batch B-2026-016"},{"dotClass":"","title":"50 samples received at drop-off","date":"Apr 14, 2026"}]'
+);
+
+
+-- AGREEMENTS (one row per agreement per study)
+
+insert into agreements (study_id, id, name, description, status, signed_by, signed_date, signed_email, sent_date, reminder_date) values
+-- BHB ColCan (3 signed, 1 pending)
+('bhb-colcan','ua','User Agreement','Master scope of work between PI and I3H','Signed','Robert Katona','Jan 24, 2026 at 2:48 PM','katona@pennmedicine.upenn.edu',null,null),
+('bhb-colcan','rs','Rate Schedule','Penn Internal — Jan 2026 rate card','Signed','Robert Katona','Jan 24, 2026 at 2:51 PM','katona@pennmedicine.upenn.edu',null,null),
+('bhb-colcan','lv','LabVantage Sample Intake Form','Sample ID assignment authorization','Signed','Robert Katona','Jan 28, 2026 at 11:14 AM','katona@pennmedicine.upenn.edu',null,null),
+('bhb-colcan','psa','Pennsieve Data Sharing Agreement','Data hosting + access controls on Pennsieve workspace','Pending',null,null,null,'May 01','May 08'),
+-- PRINCE-Val (all signed)
+('prince-val','ua','User Agreement','Master scope of work','Signed','Robert Vonderheide','Feb 10, 2025 at 9:12 AM','vonderheide@pennmedicine.upenn.edu',null,null),
+('prince-val','rs','Rate Schedule','Penn Internal — 2025 rate card','Signed','Robert Vonderheide','Feb 10, 2025 at 9:14 AM','vonderheide@pennmedicine.upenn.edu',null,null),
+('prince-val','lv','LabVantage Sample Intake Form','Sample ID assignment','Signed','Robert Vonderheide','Feb 12, 2025','vonderheide@pennmedicine.upenn.edu',null,null),
+('prince-val','psa','Pennsieve Data Sharing Agreement','Data hosting + access controls','Signed','Robert Vonderheide','Feb 12, 2025','vonderheide@pennmedicine.upenn.edu',null,null),
+-- SURGE-Christie (2 signed, 2 pending)
+('surge-christie','ua','User Agreement','Master scope of work','Signed','Michael Christie','Apr 02, 2026 at 10:32 AM','christie@pennmedicine.upenn.edu',null,null),
+('surge-christie','rs','Rate Schedule','Penn Internal — Jan 2026 rate card','Signed','Michael Christie','Apr 02, 2026 at 10:35 AM','christie@pennmedicine.upenn.edu',null,null),
+('surge-christie','lv','LabVantage Sample Intake Form','Sample ID assignment','Pending',null,null,null,'Apr 10','Apr 17'),
+('surge-christie','psa','Pennsieve Data Sharing Agreement','Data hosting + access controls','Pending',null,null,null,'Apr 10',null),
+-- TITAN-Harvard (all signed)
+('titan-harvard','ua','User Agreement','Master scope of work','Signed','Wei Chen','Nov 04, 2025','chen@harvard.edu',null,null),
+('titan-harvard','rs','Rate Schedule','External rate card','Signed','Wei Chen','Nov 04, 2025','chen@harvard.edu',null,null),
+('titan-harvard','lv','LabVantage Sample Intake Form','Sample ID assignment','Signed','Wei Chen','Nov 06, 2025','chen@harvard.edu',null,null),
+('titan-harvard','psa','Pennsieve Data Sharing Agreement','Data hosting + access controls','Signed','Wei Chen','Nov 06, 2025','chen@harvard.edu',null,null),
+-- IMMUNE-Stanford (all signed)
+('immune-stanford','ua','User Agreement','Master scope of work','Signed','Anjali Patel','Mar 14, 2025','patel@stanford.edu',null,null),
+('immune-stanford','rs','Rate Schedule','External rate card','Signed','Anjali Patel','Mar 14, 2025','patel@stanford.edu',null,null),
+('immune-stanford','lv','LabVantage Sample Intake Form','Sample ID assignment','Signed','Anjali Patel','Mar 15, 2025','patel@stanford.edu',null,null),
+('immune-stanford','psa','Pennsieve Data Sharing Agreement','Data hosting + access controls','Signed','Anjali Patel','Mar 15, 2025','patel@stanford.edu',null,null),
+-- NOVA-BioGen (all signed)
+('nova-biogen','ua','User Agreement','Master scope of work','Signed','Elena Martinez','Jan 05, 2026','martinez@biogen.com',null,null),
+('nova-biogen','rs','Rate Schedule','Industry rate card','Signed','Elena Martinez','Jan 05, 2026','martinez@biogen.com',null,null),
+('nova-biogen','lv','LabVantage Sample Intake Form','Sample ID assignment','Signed','Elena Martinez','Jan 07, 2026','martinez@biogen.com',null,null),
+('nova-biogen','psa','Pennsieve Data Sharing Agreement','Data hosting + access controls','Signed','Elena Martinez','Jan 07, 2026','martinez@biogen.com',null,null);


### PR DESCRIPTION
Admin Portal — Full Implementation 
                                                                                                                                                                                                        
Added a complete internal admin console for I3H operations staff to manage PI inquiries and active studies, backed by Supabase.

  Admin portal (/admin)
  - Login page with Supabase email/password authentication
  - Global route middleware protecting all /admin/* routes (except login and PI signing pages)
  - Dedicated admin layout with sidebar navigation
  - Admin-specific SCSS (assets/css/admin.scss)

  Inquiries
  - /admin/inquiries — list view of all PI intake submissions with status badges
  - /admin/inquiries/[id] — detail view with full intake snapshot, feasibility checklist, reviewer notes, and action buttons
  - Approve & send agreement — creates a study record, generates all 4 agreements, emails the PI a signed-link package (48-hour expiry), and navigates to the new study
  - Decline — marks the inquiry declined with a confirmation prompt

  Studies
  - /admin/studies — list view with stage, cohort, agreement progress, and budget at a glance
  - /admin/studies/[id] — tabbed detail view: overview, agreements, cohort, budget, notes & activity
  - Agreements tab shows signed/pending status per document with a Send/Resend secure link button that emails the PI a fresh JWT-signed link

  PI agreement signing (/admin/sign/[token])
  - Public-facing page (no admin auth required) that PIs land on from their email
  - Shows the full agreement document with PI details pre-populated
  - Admin preview mode (yellow banner, sign button disabled) when accessed without a valid token
  - Submit posts to a server-side endpoint that verifies the JWT before writing to Supabase

  Intake form → Supabase pipeline
  - Submissions now write to the inquiries table before sending emails (atomic — fails the whole request if the DB write fails)
  - Stores service details with human-readable names/rates, pre-populates a feasibility checklist, and maps form values to readable labels

  Secure signing infrastructure (server/utils/signing.ts)
  - HMAC-SHA256 JWT utility (no external deps) using Node's built-in crypto
  - Tokens encode studyId, agreementId, piEmail, and a 48-hour expiry
  - Server verifies signature + expiry + studyId/agreementId match before accepting any signature submission

  Supabase schema & seed (supabase/)
  - Migration: inquiries, studies, and agreements tables with RLS policies (authenticated admin staff only; PI signing uses service role)
  - Seed: representative mock data covering all study stages (Awaiting Signature → Complete) and inquiry statuses

  New environment variables

  SIGNING_SECRET= # 64-char hex secret for signing PI agreement links
  NUXT_PUBLIC_SUPABASE_URL=
  NUXT_PUBLIC_SUPABASE_KEY=
  NUXT_SUPABASE_SECRET_KEY=