### PR TITLE
Harden intake form submission and fix sign page RLS bypass

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -76,4 +76,8 @@ export default defineNuxtConfig({
   },
 
   compatibilityDate: '2024-11-01',
+
+  experimental: {
+    appManifest: false,
+  },
 })

--- a/pages/admin/sign/[token].vue
+++ b/pages/admin/sign/[token].vue
@@ -19,17 +19,11 @@ const agreementId = computed(() => {
   return parts[parts.length - 1]
 })
 
-// Fetch study + agreement details from Supabase using the service route
-// (sign page is public — no admin auth required)
-const { data: studyRow } = await useAsyncData(`sign-study-${studyId.value}`, async () => {
-  const supabase = useSupabaseClient()
-  const { data } = await supabase
-    .from('studies')
-    .select('name, abbreviation, irb, pi, affiliation_org, cohort, budget, agreements(*)')
-    .eq('id', studyId.value)
-    .single()
-  return data
-})
+// Fetch via server endpoint (uses service role — bypasses RLS for unauthenticated PIs)
+const { data: studyRow, error: studyError } = await useAsyncData(
+  `sign-study-${token.value}`,
+  () => $fetch(`/api/sign/${token.value}`),
+)
 
 const study = computed(() => studyRow.value)
 
@@ -110,7 +104,12 @@ async function submitSigned() {
       Admin preview — this is what the PI sees. Signing is disabled without a valid secure link.
     </div>
 
-    <div class="sign-wrap" v-if="study && agreement">
+    <div v-if="studyError" style="max-width:480px;margin:4rem auto;text-align:center;padding:2rem;">
+      <p style="font-size:1rem;font-weight:600;color:#c0392b;">Unable to load document</p>
+      <p style="font-size:0.85rem;color:#666;margin-top:0.5rem;">This link may be invalid or the study could not be found. Please contact your I3H representative.</p>
+    </div>
+
+    <div class="sign-wrap" v-else-if="study && agreement">
       <!-- Success confirmation (after submit) -->
       <div v-if="isSubmitted" class="sign-confirm-card">
         <div class="check-circle">✓</div>

--- a/pages/intake.vue
+++ b/pages/intake.vue
@@ -102,6 +102,30 @@ const submitForm = async () => {
     return
   }
 
+
+  // Validate email format
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+  if (!emailRegex.test(form.piEmail)) {
+    submitMessage.value = '⚠ Please enter a valid PI email address.'
+    submitSuccess.value = false
+    return
+  }
+  if (!emailRegex.test(form.leadEmail)) {
+    submitMessage.value = '⚠ Please enter a valid lead email address.'
+    submitSuccess.value = false
+    return
+  }
+  if (form.baEmail && !emailRegex.test(form.baEmail)) {
+    submitMessage.value = '⚠ Please enter a valid Business Administrator email address.'
+    submitSuccess.value = false
+    return
+  }
+  if (form.externalContact && !emailRegex.test(form.externalContact)) {
+    submitMessage.value = '⚠ Please enter a valid Contracting / Grants Office email address.'
+    submitSuccess.value = false
+    return
+  }
+
   isSubmitting.value = true
   submitMessage.value = 'Sending inquiry...'
 
@@ -135,9 +159,10 @@ const submitForm = async () => {
     submitMessage.value = '✓ Inquiry submitted! Check your email for confirmation.'
     submitSuccess.value = true
   }
-  catch (error) {
-    console.error('Submission error:', error)
-    submitMessage.value = '❌ Failed to submit. Please try again or contact us directly.'
+  catch (error: unknown) {
+    const err = error as { data?: { statusMessage?: string } }
+    const reason = err.data?.statusMessage || 'Failed to submit. Please try again or contact us directly.'
+    submitMessage.value = `❌ ${reason}`
     submitSuccess.value = false
   }
   finally {
@@ -236,11 +261,11 @@ const { data: intakePage } = await useAsyncData('intakePage', () =>
           <div class="form-row">
             <div class="form-group">
               <label>Estimated Unique Subjects <span class="req">*</span></label>
-              <input v-model.number="form.subjectCount" type="number" placeholder="20">
+              <input v-model.number="form.subjectCount" type="number" min="0" placeholder="20" @input="form.subjectCount = Math.max(0, form.subjectCount)">
             </div>
             <div class="form-group">
               <label>Time Points per Subject <span class="req">*</span></label>
-              <input v-model.number="form.timepointCount" type="number" placeholder="3">
+              <input v-model.number="form.timepointCount" type="number" min="0" placeholder="3" @input="form.timepointCount = Math.max(0, form.timepointCount)">
             </div>
           </div>
 

--- a/server/api/sign/[token].get.ts
+++ b/server/api/sign/[token].get.ts
@@ -1,0 +1,20 @@
+import { serverSupabaseServiceRole } from '#supabase/server'
+
+export default defineEventHandler(async (event) => {
+  const pathToken = getRouterParam(event, 'token')!
+  const parts = pathToken.split('-')
+  const studyId = parts.slice(0, -1).join('-')
+
+  const supabase = serverSupabaseServiceRole(event)
+  const { data, error } = await supabase
+    .from('studies')
+    .select('name, abbreviation, irb, pi, affiliation_org, cohort, budget, agreements(*)')
+    .eq('id', studyId)
+    .single()
+
+  if (error || !data) {
+    throw createError({ statusCode: 404, statusMessage: 'Study not found' })
+  }
+
+  return data
+})

--- a/server/api/submit-intake.post.ts
+++ b/server/api/submit-intake.post.ts
@@ -30,13 +30,25 @@ export default defineEventHandler(async (event) => {
 
   if (!config.mailersendApiKey) {
     console.error('MAILERSEND_API_KEY is not configured')
-    throw createError({
-      statusCode: 500,
-      statusMessage: 'Email service configuration error',
-    })
+    throw createError({ statusCode: 500, statusMessage: 'Email service configuration error' })
   }
 
   const { form, estimatedTotal, totalSamples, servicesText, servicesDetail } = body
+
+  // Validate all email addresses before touching the DB
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+  if (!emailRegex.test(form.piEmail)) {
+    throw createError({ statusCode: 400, statusMessage: 'PI email address is invalid' })
+  }
+  if (form.leadEmail && !emailRegex.test(form.leadEmail)) {
+    throw createError({ statusCode: 400, statusMessage: 'Lead email address is invalid' })
+  }
+  if (form.baEmail && !emailRegex.test(form.baEmail)) {
+    throw createError({ statusCode: 400, statusMessage: 'Business Administrator email address is invalid' })
+  }
+  if (form.externalContact && !emailRegex.test(form.externalContact)) {
+    throw createError({ statusCode: 400, statusMessage: 'Contracting / Grants Office email address is invalid' })
+  }
 
   if (!form || !form.piEmail) {
     throw createError({
@@ -98,6 +110,7 @@ export default defineEventHandler(async (event) => {
 
   // 1. Save to Supabase first — if this fails the whole request fails before emails are sent
   const supabase = serverSupabaseServiceRole(event)
+  const inquiryId = crypto.randomUUID()
   const submittedDate = new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
   const affiliationOrg = form.affiliation === 'internal'
     ? 'University of Pennsylvania'
@@ -108,7 +121,7 @@ export default defineEventHandler(async (event) => {
     : []
 
   const { error: dbError } = await supabase.from('inquiries').insert({
-    id: crypto.randomUUID(),
+    id: inquiryId,
     study_name: form.projectName,
     abbreviation: form.acronym || null,
     status: 'New',
@@ -140,7 +153,7 @@ export default defineEventHandler(async (event) => {
 
   if (dbError) {
     console.error('Supabase insert error:', dbError)
-    throw createError({ statusCode: 500, statusMessage: 'Failed to save inquiry' })
+    throw createError({ statusCode: 500, statusMessage: `Failed to save inquiry: ${dbError.message}` })
   }
 
   // 2. Send emails
@@ -182,9 +195,20 @@ export default defineEventHandler(async (event) => {
     })
   }
   catch (error: unknown) {
-    const err = error as { data?: unknown; message?: string }
+    const err = error as { data?: { message?: string; errors?: Record<string, string[]> }; message?: string }
     console.error('Error sending email via MailerSend:', err.data || err.message)
-    throw createError({ statusCode: 500, statusMessage: 'Failed to send confirmation emails' })
+
+    // Roll back the DB insert so there's no orphan record
+    await supabase.from('inquiries').delete().eq('id', inquiryId)
+
+    // Surface the first specific MailerSend validation error if available
+    const firstMailerError = err.data?.errors
+      ? Object.values(err.data.errors)[0]?.[0]
+      : null
+    throw createError({
+      statusCode: 500,
+      statusMessage: firstMailerError || err.data?.message || 'Failed to send confirmation emails',
+    })
   }
 
   return { success: true }

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -1,0 +1,1 @@
+export type Database = Record<string, unknown>


### PR DESCRIPTION
  - Validate all four email fields (PI, lead, BA, contracting contact)
    on both client and server before touching the database
  - Roll back the Supabase inquiry record if MailerSend fails, preventing
    orphan records when email delivery errors occur
  - Surface the specific server error message in the UI instead of a
    generic fallback
  - Prevent negative values in subject/timepoint number inputs
  - Fix sign page intermittent failures: fetch study data via a server
    endpoint using the service role key, bypassing RLS for unauthenticated PIs
  - Add database types stub to suppress @nuxtjs/supabase type warning
  - Disable app manifest feature to work around a Nuxt 3.21.4 build error