### PR TITLE
Fix timezone bugs, stale relative times, and hardcoded constants

### DIFF
--- a/composables/useRelativeTime.ts
+++ b/composables/useRelativeTime.ts
@@ -1,0 +1,24 @@
+export function useRelativeTime() {
+  function relativeTime(dateStr: string): string {
+    if (!dateStr) return ''
+    const date = new Date(dateStr)
+    if (isNaN(date.getTime())) return ''
+
+    const diff = Date.now() - date.getTime()
+    const minutes = Math.floor(diff / 60_000)
+    const hours = Math.floor(diff / 3_600_000)
+    const days = Math.floor(diff / 86_400_000)
+    const weeks = Math.floor(days / 7)
+    const months = Math.floor(days / 30)
+
+    if (minutes < 1) return 'just now'
+    if (minutes < 60) return `${minutes}m ago`
+    if (hours < 24) return `${hours}h ago`
+    if (days === 1) return 'yesterday'
+    if (days < 7) return `${days}d ago`
+    if (weeks < 5) return `${weeks}w ago`
+    return `${months}mo ago`
+  }
+
+  return { relativeTime }
+}

--- a/pages/admin/inquiries/[id].vue
+++ b/pages/admin/inquiries/[id].vue
@@ -3,6 +3,7 @@ import { useAdminStore } from '~/stores/admin'
 
 definePageMeta({ layout: 'admin' })
 
+const { relativeTime } = useRelativeTime()
 const route = useRoute()
 const adminStore = useAdminStore()
 
@@ -36,7 +37,7 @@ async function postNote() {
   try {
     const { note } = await $fetch('/api/admin/add-inquiry-note', {
       method: 'POST',
-      body: { inquiryId: inquiry.value.id, text: noteText.value, author: adminStore.user.name },
+      body: { inquiryId: inquiry.value.id, text: noteText.value, author: adminStore.user.name, timezone: Intl.DateTimeFormat().resolvedOptions().timeZone },
     }) as { note: { author: string; date: string; text: string } }
     inquiry.value.notes.unshift(note)
     noteText.value = ''
@@ -69,7 +70,7 @@ async function approveAndSend() {
   try {
     const { studyId } = await $fetch('/api/admin/approve-inquiry', {
       method: 'POST',
-      body: { inquiryId: inquiry.value.id },
+      body: { inquiryId: inquiry.value.id, timezone: Intl.DateTimeFormat().resolvedOptions().timeZone },
     }) as { studyId: string }
     await adminStore.loadAll()
     navigateTo(`/admin/studies/${studyId}`)
@@ -134,7 +135,7 @@ async function confirmDecline() {
         <div class="meta-strip">
           <div class="meta-item">
             <span class="meta-label">Submitted</span>
-            <span class="meta-val">{{ inquiry.submittedDate }} · {{ inquiry.submittedRelative }}</span>
+            <span class="meta-val">{{ inquiry.submittedDate }} · {{ relativeTime(inquiry.createdAt) }}</span>
           </div>
           <div class="meta-item">
             <span class="meta-label">IRB</span>

--- a/pages/admin/inquiries/index.vue
+++ b/pages/admin/inquiries/index.vue
@@ -3,6 +3,8 @@ import { useAdminStore } from '~/stores/admin'
 
 definePageMeta({ layout: 'admin' })
 
+const { relativeTime } = useRelativeTime()
+
 const adminStore = useAdminStore()
 const activeFilter = ref('New')
 const searchQuery = ref('')
@@ -100,7 +102,7 @@ const displayedInquiries = computed(() => {
             <td>
               <div class="mono" style="font-size:0.78rem">{{ inquiry.submittedDate }}</div>
               <div class="study-pi" :style="inquiry.isStale ? 'color:var(--warm)' : ''">
-                {{ inquiry.submittedRelative }}
+                {{ relativeTime(inquiry.createdAt) }}
               </div>
             </td>
             <td>

--- a/pages/admin/sign/[token].vue
+++ b/pages/admin/sign/[token].vue
@@ -66,6 +66,7 @@ async function submitSigned() {
         signerName: signerName.value,
         signerEmail: signerEmail.value,
         token: signToken.value,
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
       },
     })
     isSubmitted.value = true
@@ -128,7 +129,7 @@ async function submitSigned() {
       <div class="sign-doc">
         <div class="sign-doc-head">
           <h2>{{ (agreement as any).name }}</h2>
-          <div class="doc-meta">Ref: {{ study.abbreviation }}-{{ String((agreement as any).id).toUpperCase() }}-2026 · I3H/{{ study.irb }}</div>
+          <div class="doc-meta">Ref: {{ study.abbreviation }}-{{ String((agreement as any).id).toUpperCase() }}-{{ new Date().getFullYear() }} · I3H/{{ study.irb }}</div>
         </div>
 
         <div class="sign-doc-body">

--- a/pages/admin/studies/[id].vue
+++ b/pages/admin/studies/[id].vue
@@ -31,7 +31,7 @@ async function sendSignLink(studyId: string, agreementId: string) {
   try {
     await $fetch('/api/admin/send-sign-link', {
       method: 'POST',
-      body: { studyId, agreementId },
+      body: { studyId, agreementId, timezone: Intl.DateTimeFormat().resolvedOptions().timeZone },
     })
     sentLink.value = new Set([...sentLink.value, key])
   }
@@ -77,7 +77,7 @@ async function postNote() {
   try {
     const { activityItem } = await $fetch('/api/admin/add-study-note', {
       method: 'POST',
-      body: { studyId: study.value.id, text: noteText.value, author: adminStore.user.name },
+      body: { studyId: study.value.id, text: noteText.value, author: adminStore.user.name, timezone: Intl.DateTimeFormat().resolvedOptions().timeZone },
     }) as { activityItem: { dotClass: string; title: string; date: string; note: string; ts: number } }
     study.value.activity.unshift(activityItem)
     noteText.value = ''

--- a/pages/admin/studies/index.vue
+++ b/pages/admin/studies/index.vue
@@ -4,6 +4,8 @@ import type { StudyStage, Affiliation } from '~/stores/admin'
 
 definePageMeta({ layout: 'admin' })
 
+const { relativeTime } = useRelativeTime()
+
 const adminStore = useAdminStore()
 const stageFilter = ref<StudyStage | 'All'>('All')
 const affiliationFilter = ref<Affiliation | 'All affiliations'>('All affiliations')
@@ -180,7 +182,7 @@ const signedCount = (study: typeof adminStore.studies[0]) =>
                 {{ study.stage === 'Complete' ? 'final' : 'est. $' + (study.budget.committed / 1000).toFixed(0) + 'K' }}
               </div>
             </td>
-            <td class="mono" style="font-size:0.78rem; color:var(--muted)">{{ study.updatedRelative }}</td>
+            <td class="mono" style="font-size:0.78rem; color:var(--muted)">{{ relativeTime(study.updatedAt) }}</td>
           </tr>
         </tbody>
       </table>

--- a/pages/intake.vue
+++ b/pages/intake.vue
@@ -153,6 +153,7 @@ const submitForm = async () => {
         totalSamples: totalSamples.value,
         servicesText,
         servicesDetail,
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
       },
     })
 

--- a/server/api/admin/add-inquiry-note.post.ts
+++ b/server/api/admin/add-inquiry-note.post.ts
@@ -1,7 +1,7 @@
 import { serverSupabaseServiceRole } from '#supabase/server'
 
 export default defineEventHandler(async (event) => {
-  const { inquiryId, text, author } = await readBody(event)
+  const { inquiryId, text, author, timezone } = await readBody(event)
 
   if (!inquiryId || !text?.trim() || !author) {
     throw createError({ statusCode: 400, statusMessage: 'Missing required fields' })
@@ -19,7 +19,8 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 404, statusMessage: 'Inquiry not found' })
   }
 
-  const date = new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
+  const tz = timezone || DEFAULT_TIMEZONE
+  const date = new Date().toLocaleDateString('en-US', { timeZone: tz, month: 'long', day: 'numeric', year: 'numeric' })
 
   const newNote = { author, date, text: text.trim() }
   const updatedNotes = [newNote, ...((inquiry.notes as unknown[]) || [])]

--- a/server/api/admin/add-study-note.post.ts
+++ b/server/api/admin/add-study-note.post.ts
@@ -1,7 +1,7 @@
 import { serverSupabaseServiceRole } from '#supabase/server'
 
 export default defineEventHandler(async (event) => {
-  const { studyId, text, author } = await readBody(event)
+  const { studyId, text, author, timezone } = await readBody(event)
 
   if (!studyId || !text?.trim() || !author) {
     throw createError({ statusCode: 400, statusMessage: 'Missing required fields' })
@@ -20,8 +20,9 @@ export default defineEventHandler(async (event) => {
   }
 
   const now = new Date()
-  const dateStr = now.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
-    + ' · ' + now.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
+  const tz = timezone || DEFAULT_TIMEZONE
+  const dateStr = now.toLocaleDateString('en-US', { timeZone: tz, month: 'short', day: 'numeric', year: 'numeric' })
+    + ' · ' + now.toLocaleTimeString('en-US', { timeZone: tz, hour: 'numeric', minute: '2-digit' })
     + ' · internal note'
 
   const newItem = {

--- a/server/api/admin/approve-inquiry.post.ts
+++ b/server/api/admin/approve-inquiry.post.ts
@@ -1,12 +1,6 @@
 import { serverSupabaseServiceRole } from '#supabase/server'
 import { createSignToken } from '~/server/utils/signing'
-
-const AGREEMENTS = [
-  { id: 'ua',  name: 'User Agreement',                description: 'Master scope of work between PI and I3H' },
-  { id: 'rs',  name: 'Rate Schedule',                 description: 'Itemized pricing and billing terms' },
-  { id: 'lv',  name: 'LabVantage Sample Intake Form', description: 'Sample ID assignment authorization' },
-  { id: 'psa', name: 'Pennsieve Data Sharing Agreement', description: 'Data hosting + access controls on Pennsieve workspace' },
-]
+import { AGREEMENTS } from '~/utils/agreements'
 
 function parseRate(rateStr: string): number {
   const match = rateStr.match(/\$?([\d,]+)/)
@@ -15,7 +9,7 @@ function parseRate(rateStr: string): number {
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
-  const { inquiryId } = await readBody(event)
+  const { inquiryId, timezone } = await readBody(event)
 
   if (!inquiryId) {
     throw createError({ statusCode: 400, statusMessage: 'Missing inquiryId' })
@@ -36,7 +30,8 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 409, statusMessage: 'Inquiry already processed' })
   }
 
-  const approvedDate = new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+  const tz = timezone || DEFAULT_TIMEZONE
+  const approvedDate = new Date().toLocaleDateString('en-US', { timeZone: tz, month: 'short', day: 'numeric', year: 'numeric' })
 
   // Generate a unique study ID from the abbreviation
   const abbr = ((inquiry.abbreviation as string) || (inquiry.study_name as string))

--- a/server/api/admin/send-sign-link.post.ts
+++ b/server/api/admin/send-sign-link.post.ts
@@ -1,23 +1,17 @@
 import { serverSupabaseServiceRole } from '#supabase/server'
 import { createSignToken } from '~/server/utils/signing'
-
-const VALID_AGREEMENT_IDS = ['ua', 'rs', 'lv', 'psa']
-const AGREEMENT_NAMES: Record<string, string> = {
-  ua: 'Usage Agreement',
-  rs: 'Rate Schedule',
-  lv: 'LabVantage Access Agreement',
-  psa: 'Professional Services Agreement',
-}
+import { AGREEMENT_IDS, AGREEMENT_NAMES } from '~/utils/agreements'
+import { DEFAULT_TIMEZONE } from '~/server/utils/constants'
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
   const body = await readBody(event)
-  const { studyId, agreementId } = body
+  const { studyId, agreementId, timezone } = body
 
   if (!studyId || !agreementId) {
     throw createError({ statusCode: 400, statusMessage: 'Missing studyId or agreementId' })
   }
-  if (!VALID_AGREEMENT_IDS.includes(agreementId)) {
+  if (!AGREEMENT_IDS.includes(agreementId)) {
     throw createError({ statusCode: 400, statusMessage: 'Invalid agreement ID' })
   }
   if (!config.signingSecret) {
@@ -56,7 +50,8 @@ export default defineEventHandler(async (event) => {
     },
   })
 
-  const sentDate = new Date().toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+  const tz = timezone || DEFAULT_TIMEZONE
+  const sentDate = new Date().toLocaleDateString('en-US', { timeZone: tz, month: 'short', day: 'numeric', year: 'numeric' })
   await supabase
     .from('agreements')
     .update({ sent_date: sentDate })

--- a/server/api/admin/sign-agreement.post.ts
+++ b/server/api/admin/sign-agreement.post.ts
@@ -1,17 +1,17 @@
 import { serverSupabaseServiceRole } from '#supabase/server'
 import { verifySignToken } from '~/server/utils/signing'
-
-const VALID_AGREEMENT_IDS = ['ua', 'rs', 'lv', 'psa']
+import { AGREEMENT_IDS, AGREEMENT_COUNT } from '~/utils/agreements'
+import { DEFAULT_TIMEZONE } from '~/server/utils/constants'
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
   const body = await readBody(event)
-  const { studyId, agreementId, signerName, signerEmail, token } = body
+  const { studyId, agreementId, signerName, signerEmail, token, timezone } = body
 
   if (!studyId || !agreementId || !signerName || !signerEmail) {
     throw createError({ statusCode: 400, statusMessage: 'Missing required fields' })
   }
-  if (!VALID_AGREEMENT_IDS.includes(agreementId)) {
+  if (!AGREEMENT_IDS.includes(agreementId)) {
     throw createError({ statusCode: 400, statusMessage: 'Invalid agreement ID' })
   }
 
@@ -46,8 +46,9 @@ export default defineEventHandler(async (event) => {
   }
 
   const now = new Date()
-  const signedDate = now.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
-    + ' at ' + now.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
+  const tz = timezone || DEFAULT_TIMEZONE
+  const signedDate = now.toLocaleDateString('en-US', { timeZone: tz, month: 'short', day: 'numeric', year: 'numeric' })
+    + ' at ' + now.toLocaleTimeString('en-US', { timeZone: tz, hour: 'numeric', minute: '2-digit' })
 
   const { error: updateErr } = await supabase
     .from('agreements')
@@ -65,7 +66,7 @@ export default defineEventHandler(async (event) => {
     .select('status')
     .eq('study_id', studyId)
 
-  const allSigned = allAgreements?.length === 4 && allAgreements.every(a => a.status === 'Signed')
+  const allSigned = allAgreements?.length === AGREEMENT_COUNT && allAgreements.every(a => a.status === 'Signed')
 
   if (allSigned) {
     const { data: study } = await supabase
@@ -75,9 +76,9 @@ export default defineEventHandler(async (event) => {
       .single()
 
     if (study) {
-      const lifecycle = (study.lifecycle as Array<{ label: string; date: string; status: string }>).map((step, i) => {
-        if (i === 4) return { ...step, date: 'today', status: 'done' }
-        if (i === 5) return { ...step, date: 'in progress', status: 'active' }
+      const lifecycle = (study.lifecycle as Array<{ label: string; date: string; status: string }>).map((step) => {
+        if (step.label === 'Activated') return { ...step, date: signedDate, status: 'done' }
+        if (step.label === 'Processing') return { ...step, date: 'in progress', status: 'active' }
         return step
       })
 

--- a/server/api/admin/update-study-samples.post.ts
+++ b/server/api/admin/update-study-samples.post.ts
@@ -1,7 +1,7 @@
 import { serverSupabaseServiceRole } from '#supabase/server'
 
 export default defineEventHandler(async (event) => {
-  const { studyId, processedSamples } = await readBody(event)
+  const { studyId, processedSamples, timezone } = await readBody(event)
 
   if (!studyId || typeof processedSamples !== 'number' || isNaN(processedSamples) || processedSamples < 0) {
     throw createError({ statusCode: 400, statusMessage: 'Missing or invalid fields' })
@@ -50,8 +50,9 @@ export default defineEventHandler(async (event) => {
   const updatedCohort = { ...cohort, processedSamples: clamped }
 
   const now = new Date()
-  const dateStr = now.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
-    + ' · ' + now.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
+  const tz = timezone || DEFAULT_TIMEZONE
+  const dateStr = now.toLocaleDateString('en-US', { timeZone: tz, month: 'short', day: 'numeric', year: 'numeric' })
+    + ' · ' + now.toLocaleTimeString('en-US', { timeZone: tz, hour: 'numeric', minute: '2-digit' })
 
   const activityItem = {
     dotClass: 'g',

--- a/server/api/admin/update-study.post.ts
+++ b/server/api/admin/update-study.post.ts
@@ -1,7 +1,7 @@
 import { serverSupabaseServiceRole } from '#supabase/server'
 
 export default defineEventHandler(async (event) => {
-  const { studyId, name } = await readBody(event)
+  const { studyId, name, timezone } = await readBody(event)
 
   if (!studyId || !name?.trim()) {
     throw createError({ statusCode: 400, statusMessage: 'Missing studyId or name' })
@@ -20,8 +20,9 @@ export default defineEventHandler(async (event) => {
   }
 
   const now = new Date()
-  const dateStr = now.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
-    + ' · ' + now.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
+  const tz = timezone || DEFAULT_TIMEZONE
+  const dateStr = now.toLocaleDateString('en-US', { timeZone: tz, month: 'short', day: 'numeric', year: 'numeric' })
+    + ' · ' + now.toLocaleTimeString('en-US', { timeZone: tz, hour: 'numeric', minute: '2-digit' })
 
   const newItem = {
     dotClass: '',

--- a/server/api/submit-intake.post.ts
+++ b/server/api/submit-intake.post.ts
@@ -33,7 +33,8 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 500, statusMessage: 'Email service configuration error' })
   }
 
-  const { form, estimatedTotal, totalSamples, servicesText, servicesDetail } = body
+  const { form, estimatedTotal, totalSamples, servicesText, servicesDetail, timezone } = body
+  const tz = timezone || DEFAULT_TIMEZONE
 
   // Validate all email addresses before touching the DB
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
@@ -116,7 +117,7 @@ export default defineEventHandler(async (event) => {
   // 1. Save to Supabase first — if this fails the whole request fails before emails are sent
   const supabase = serverSupabaseServiceRole(event)
   const inquiryId = crypto.randomUUID()
-  const submittedDate = new Date().toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
+  const submittedDate = new Date().toLocaleDateString('en-US', { timeZone: tz, month: 'long', day: 'numeric', year: 'numeric' })
   const affiliationOrg = form.affiliation === 'internal'
     ? 'University of Pennsylvania'
     : (form.externalInstitution || '')
@@ -178,7 +179,7 @@ export default defineEventHandler(async (event) => {
       },
     })
 
-    const submittedAt = new Date().toLocaleString('en-US', { month: 'long', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit' })
+    const submittedAt = new Date().toLocaleString('en-US', { timeZone: tz, month: 'long', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit' })
 
     const staffHtml = `
       <div style="font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;max-width:600px;margin:0 auto;color:#2d3640;line-height:1.75;font-size:0.92rem;font-weight:300;">

--- a/server/utils/constants.ts
+++ b/server/utils/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_TIMEZONE = 'America/New_York'

--- a/stores/admin.ts
+++ b/stores/admin.ts
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import { AGREEMENT_IDS } from '~/utils/agreements'
 
 export type InquiryStatus = 'New' | 'In Review' | 'Approved' | 'Declined' | 'Stale'
 export type StudyStage = 'Review' | 'Agreement' | 'Awaiting Signature' | 'Processing' | 'Complete'
@@ -9,7 +10,7 @@ export interface Inquiry {
   studyName: string
   abbreviation: string
   submittedDate: string
-  submittedRelative: string
+  createdAt: string
   isStale?: boolean
   objectives: string
   pi: { name: string; email: string }
@@ -88,7 +89,6 @@ export interface Study {
   activity: ActivityItem[]
   lifecycle: Array<{ label: string; date: string; status: 'done' | 'active' | 'pending' }>
   updatedAt: string
-  updatedRelative: string
   isLocked: boolean
   quickStats?: { samplesReceived: number; samplesTotal: number; cytofAcquired: number; cytofTotal: number; qcPassed: number; qcTotal: number; invoicedYtd: number }
 }
@@ -99,7 +99,7 @@ function mapInquiry(row: Record<string, unknown>): Inquiry {
     studyName: row.study_name as string,
     abbreviation: row.abbreviation as string,
     submittedDate: row.submitted_date as string,
-    submittedRelative: row.submitted_relative as string,
+    createdAt: row.created_at as string,
     isStale: row.is_stale as boolean,
     objectives: row.objectives as string,
     pi: row.pi as { name: string; email: string },
@@ -159,7 +159,6 @@ function mapStudy(row: Record<string, unknown>, agreements: Agreement[]): Study 
     activity: (row.activity as ActivityItem[]) || [],
     lifecycle: normalizeLifecycle((row.lifecycle as Study['lifecycle']) || []),
     updatedAt: row.updated_at as string,
-    updatedRelative: row.updated_relative as string,
     quickStats: row.quick_stats as Study['quickStats'],
   }
 }
@@ -246,8 +245,7 @@ export const useAdminStore = defineStore('admin', {
 
       this.studies = (data || []).map((row) => {
         const agreementsRaw = (row.agreements as Array<Record<string, unknown>>) || []
-        const agreementOrder = ['ua', 'rs', 'lv', 'psa']
-        const agreements = agreementOrder
+        const agreements = AGREEMENT_IDS
           .map(id => agreementsRaw.find(a => a.id === id))
           .filter(Boolean)
           .map(a => mapAgreement(a as Record<string, unknown>))
@@ -296,10 +294,10 @@ export const useAdminStore = defineStore('admin', {
               is_locked: false,
               stage: 'Processing',
               activity: updatedActivity,
-              lifecycle: study.lifecycle.map((step, i) => {
-                if (i === 3) return { ...step, date: signedDate, status: 'done' }
-                if (i === 4) return { ...step, date: 'today', status: 'done' }
-                if (i === 5) return { ...step, date: 'in progress', status: 'active' }
+              lifecycle: study.lifecycle.map((step) => {
+                if (step.label === 'Agreements') return { ...step, date: signedDate, status: 'done' }
+                if (step.label === 'Activated') return { ...step, date: signedDate, status: 'done' }
+                if (step.label === 'Processing') return { ...step, date: 'in progress', status: 'active' }
                 return step
               }),
             })
@@ -308,9 +306,12 @@ export const useAdminStore = defineStore('admin', {
           study.isLocked = false
           study.stage = 'Processing'
           study.activity = updatedActivity
-          study.lifecycle[3] = { ...study.lifecycle[3], date: signedDate, status: 'done' }
-          study.lifecycle[4] = { label: 'Activated', date: 'today', status: 'done' }
-          study.lifecycle[5] = { label: 'Processing', date: 'in progress', status: 'active' }
+          study.lifecycle = study.lifecycle.map(step => {
+            if (step.label === 'Agreements') return { ...step, date: signedDate, status: 'done' }
+            if (step.label === 'Activated') return { ...step, date: signedDate, status: 'done' }
+            if (step.label === 'Processing') return { ...step, date: 'in progress', status: 'active' }
+            return step
+          })
         }
       }
     },
@@ -318,7 +319,7 @@ export const useAdminStore = defineStore('admin', {
     async updateProcessedSamples(studyId: string, processedSamples: number) {
       const result = await $fetch<{ success: boolean; cohort: Study['cohort']; budget: Study['budget']; activityItem: ActivityItem }>('/api/admin/update-study-samples', {
         method: 'POST',
-        body: { studyId, processedSamples },
+        body: { studyId, processedSamples, timezone: Intl.DateTimeFormat().resolvedOptions().timeZone },
       })
       const study = this.studies.find(s => s.id === studyId)
       if (study) {
@@ -331,7 +332,7 @@ export const useAdminStore = defineStore('admin', {
     async updateStudyName(studyId: string, name: string) {
       const result = await $fetch<{ success: boolean; activityItem: ActivityItem }>('/api/admin/update-study', {
         method: 'POST',
-        body: { studyId, name },
+        body: { studyId, name, timezone: Intl.DateTimeFormat().resolvedOptions().timeZone },
       })
       const study = this.studies.find(s => s.id === studyId)
       if (study) {

--- a/utils/agreements.ts
+++ b/utils/agreements.ts
@@ -1,0 +1,14 @@
+export const AGREEMENTS = [
+  { id: 'ua',  name: 'User Agreement',                  description: 'Master scope of work between PI and I3H' },
+  { id: 'rs',  name: 'Rate Schedule',                   description: 'Itemized pricing and billing terms' },
+  { id: 'lv',  name: 'LabVantage Sample Intake Form',   description: 'Sample ID assignment authorization' },
+  { id: 'psa', name: 'Pennsieve Data Sharing Agreement', description: 'Data hosting + access controls on Pennsieve workspace' },
+] as const
+
+export type AgreementId = typeof AGREEMENTS[number]['id']
+
+export const AGREEMENT_IDS: AgreementId[] = AGREEMENTS.map(a => a.id)
+export const AGREEMENT_COUNT = AGREEMENTS.length
+export const AGREEMENT_NAMES: Record<AgreementId, string> = Object.fromEntries(
+  AGREEMENTS.map(a => [a.id, a.name])
+) as Record<AgreementId, string>


### PR DESCRIPTION
- Pass browser timezone to all server API routes so dates and times are
  formatted in the user's local timezone rather than UTC; fixes activity
  log entries showing the wrong date when actions are taken in the evening
- Replace frozen "just now" relative timestamps with a useRelativeTime
  composable that computes live relative times from ISO timestamps
- Centralise agreement definitions in utils/agreements.ts — single source
  of truth for IDs, names, and descriptions, eliminating inconsistent
  names across files (e.g. "Usage Agreement" vs "User Agreement")
- Replace hardcoded agreement count (=== 4) with AGREEMENT_COUNT derived
  from the shared list
- Replace magic lifecycle array indices (i === 3/4/5) with label matching
  so lifecycle updates are not order-dependent
- Centralise timezone fallback in server/utils/constants.ts (DEFAULT_TIMEZONE)
  instead of repeating 'America/New_York' across 8 routes
- Fix hardcoded year 2026 in agreement docum
  new Date().getFullYear()