### PR TITLE
fix budget bug and auto sign out

### DIFF
--- a/layouts/admin.vue
+++ b/layouts/admin.vue
@@ -48,11 +48,16 @@ onMounted(async () => {
   const { data: { session } } = await supabase.auth.getSession()
   if (session?.expires_at) {
     sessionExpiresAt.value = session.expires_at
-    sessionTimer = setInterval(() => {
-      // Force recompute every minute; also refresh the stored value from the live session
-      supabase.auth.getSession().then(({ data: { session: s } }) => {
-        if (s?.expires_at) sessionExpiresAt.value = s.expires_at
-      })
+    sessionTimer = setInterval(async () => {
+      const { data: { session: s } } = await supabase.auth.getSession()
+      if (s?.expires_at) {
+        sessionExpiresAt.value = s.expires_at
+      }
+      else {
+        clearInterval(sessionTimer!)
+        await adminStore.logout()
+        navigateTo('/admin/login')
+      }
     }, 60000)
   }
 })

--- a/pages/admin/inquiries/[id].vue
+++ b/pages/admin/inquiries/[id].vue
@@ -203,7 +203,7 @@ async function confirmDecline() {
           <div class="info-lbl">Services</div>
           <div>
             <div v-for="svc in inquiry.servicesDetail" :key="svc.name">
-              {{ svc.name }} × {{ svc.qty }} — <span class="mono">{{ svc.rate }}</span>
+              {{ svc.name }} × {{ svc.qty }} — <span class="mono">{{ typeof svc.rate === 'number' ? (svc.rate === 0 ? 'Contact' : `$${svc.rate}/ea`) : svc.rate }}</span>
             </div>
           </div>
 

--- a/pages/intake.vue
+++ b/pages/intake.vue
@@ -137,11 +137,10 @@ const submitForm = async () => {
 
     const servicesDetail = form.services.map((req) => {
       const service = servicesStore.services.find(s => s.id === req.serviceId)
-      const rate = servicesStore.getServiceRate(req.serviceId)
       return {
         name: service?.name || req.serviceId,
         qty: req.quantity,
-        rate: rate === 0 ? 'Contact' : `$${rate}/ea`,
+        rate: servicesStore.getServiceRate(req.serviceId),
       }
     })
 

--- a/pages/services.vue
+++ b/pages/services.vue
@@ -33,7 +33,7 @@ const formatRate = (service: any): string => {
   }
 
   // Default formatting for single-value rates
-  const rate = servicesStore.rateView === 'internal' ? service.internalRate : service.externalRate
+  const rate = (servicesStore.rateView === 'internal' ? service.internalRate : service.externalRate) ?? 0
   if (rate === 0) return 'Contact'
   return `$${rate.toLocaleString()}`
 }

--- a/server/api/admin/approve-inquiry.post.ts
+++ b/server/api/admin/approve-inquiry.post.ts
@@ -2,8 +2,9 @@ import { serverSupabaseServiceRole } from '#supabase/server'
 import { createSignToken } from '~/server/utils/signing'
 import { AGREEMENTS } from '~/utils/agreements'
 
-function parseRate(rateStr: string): number {
-  const match = rateStr.match(/\$?([\d,]+)/)
+function parseRate(rateVal: string | number): number {
+  if (typeof rateVal === 'number') return rateVal
+  const match = rateVal.match(/\$?([\d,]+)/)
   return match ? parseInt(match[1].replace(/,/g, '')) : 0
 }
 
@@ -41,7 +42,7 @@ export default defineEventHandler(async (event) => {
   const studyId = `${abbr}-${Math.random().toString(36).slice(2, 6)}`
 
   // Build budget lines from services_detail
-  const servicesDetail = (inquiry.services_detail as Array<{ name: string; qty: number; rate: string }>) || []
+  const servicesDetail = (inquiry.services_detail as Array<{ name: string; qty: number; rate: string | number }>) || []
   const lines = servicesDetail.map(svc => {
     const rate = parseRate(svc.rate)
     return {

--- a/stores/admin.ts
+++ b/stores/admin.ts
@@ -21,7 +21,7 @@ export interface Inquiry {
   cohortSubjects: number
   cohortTimepoints: number
   services: string
-  servicesDetail: Array<{ name: string; qty: number; rate: string }>
+  servicesDetail: Array<{ name: string; qty: number; rate: string | number }>
   status: InquiryStatus
   estimate?: number
   sampleType?: string
@@ -110,7 +110,7 @@ function mapInquiry(row: Record<string, unknown>): Inquiry {
     cohortSubjects: row.cohort_subjects as number,
     cohortTimepoints: row.cohort_timepoints as number,
     services: row.services as string,
-    servicesDetail: (row.services_detail as Array<{ name: string; qty: number; rate: string }>) || [],
+    servicesDetail: (row.services_detail as Array<{ name: string; qty: number; rate: string | number }>) || [],
     status: row.status as InquiryStatus,
     estimate: row.estimate as number | undefined,
     sampleType: row.sample_type as string | undefined,

--- a/stores/services.ts
+++ b/stores/services.ts
@@ -33,14 +33,14 @@ export const useServicesStore = defineStore('services', {
     getServiceRate: (state) => (serviceId: string): number => {
       const service = state.services.find(s => s.id === serviceId)
       if (!service) return 0
-      return state.rateView === 'internal' ? service.internalRate : service.externalRate
+      return (state.rateView === 'internal' ? service.internalRate : service.externalRate) ?? 0
     },
 
     calculateTotal: (state) => (requests: ServiceRequest[]): number => {
       return requests.reduce((total, req) => {
         const service = state.services.find(s => s.id === req.serviceId)
         if (!service) return total
-        const rate = state.rateView === 'internal' ? service.internalRate : service.externalRate
+        const rate = (state.rateView === 'internal' ? service.internalRate : service.externalRate) ?? 0
         return total + (rate * req.quantity)
       }, 0)
     },


### PR DESCRIPTION
Fix $0 budget bug and auto sign-out on session expiry

Store service rates as numbers in services_detail instead of formatted
strings (e.g. "$50/ea"), eliminating the parseRate string→number
round-trip that returned 0 whenever Contentful had an undefined rate
field. parseRate now accepts string|number for backward compat with
existing DB records. Added ?? 0 guards to getServiceRate and
calculateTotal for the same reason.

Also updated the session timer in the admin layout to sign the user out
and redirect to login if getSession() returns null, rather than leaving
an expired session silently in place.